### PR TITLE
Add basic Rust security rules

### DIFF
--- a/rust/lang/security/args-os.rs
+++ b/rust/lang/security/args-os.rs
@@ -1,0 +1,4 @@
+use std::env;
+
+// ruleid: args-os
+let args = env::args_os()

--- a/rust/lang/security/args-os.yml
+++ b/rust/lang/security/args-os.yml
@@ -1,6 +1,6 @@
 rules:
   - id: args-os
-    message: |
+    message: >-
       args_os should not be used for security operations. From the docs:
       "The first element is traditionally the path of the executable, but it
       can be set to arbitrary text, and might not even exist. This means this

--- a/rust/lang/security/args-os.yml
+++ b/rust/lang/security/args-os.yml
@@ -1,0 +1,13 @@
+rules:
+  - id: args-os
+    message: |
+      args_os should not be used for security operations. From the docs:
+      "The first element is traditionally the path of the executable, but it
+      can be set to arbitrary text, and might not even exist. This means this
+      property should not be relied upon for security purposes."
+    pattern: "std::env::args_os()"
+    metadata:
+      references:
+        - https://doc.rust-lang.org/stable/std/env/fn.args_os.html
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/args-os.yml
+++ b/rust/lang/security/args-os.yml
@@ -9,5 +9,13 @@ rules:
     metadata:
       references:
         - https://doc.rust-lang.org/stable/std/env/fn.args_os.html
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-807: Reliance on Untrusted Inputs in a Security Decision"
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/args.rs
+++ b/rust/lang/security/args.rs
@@ -1,0 +1,4 @@
+use std::env;
+
+// ruleid: args
+let args = env::args()

--- a/rust/lang/security/args.yml
+++ b/rust/lang/security/args.yml
@@ -9,5 +9,13 @@ rules:
     metadata:
       references:
         - https://doc.rust-lang.org/stable/std/env/fn.args.html
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-807: Reliance on Untrusted Inputs in a Security Decision"
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/args.yml
+++ b/rust/lang/security/args.yml
@@ -1,0 +1,13 @@
+rules:
+  - id: args
+    message: |
+      args should not be used for security operations. From the docs:
+      "The first element is traditionally the path of the executable, but it
+      can be set to arbitrary text, and might not even exist. This means this
+      property should not be relied upon for security purposes."
+    pattern: "std::env::args()"
+    metadata:
+      references:
+        - https://doc.rust-lang.org/stable/std/env/fn.args.html
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/args.yml
+++ b/rust/lang/security/args.yml
@@ -1,6 +1,6 @@
 rules:
   - id: args
-    message: |
+    message: >-
       args should not be used for security operations. From the docs:
       "The first element is traditionally the path of the executable, but it
       can be set to arbitrary text, and might not even exist. This means this

--- a/rust/lang/security/current-exe.rs
+++ b/rust/lang/security/current-exe.rs
@@ -1,0 +1,4 @@
+use std::env;
+
+// ruleid: current-exe
+let exe = env::current_exe()

--- a/rust/lang/security/current-exe.yml
+++ b/rust/lang/security/current-exe.yml
@@ -1,6 +1,6 @@
 rules:
   - id: current-exe
-    message: |
+    message: >-
       current_exe should not be used for security operations. From the docs:
       "The output of this function should not be trusted for anything that
       might have security implications. Basically, if users can run the

--- a/rust/lang/security/current-exe.yml
+++ b/rust/lang/security/current-exe.yml
@@ -9,5 +9,13 @@ rules:
     metadata:
       references:
         - https://doc.rust-lang.org/stable/std/env/fn.current_exe.html#security
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-807: Reliance on Untrusted Inputs in a Security Decision"
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/current-exe.yml
+++ b/rust/lang/security/current-exe.yml
@@ -1,0 +1,13 @@
+rules:
+  - id: current-exe
+    message: |
+      current_exe should not be used for security operations. From the docs:
+      "The output of this function should not be trusted for anything that
+      might have security implications. Basically, if users can run the
+      executable, they can change the output arbitrarily."
+    pattern: "std::env::current_exe()"
+    metadata:
+      references:
+        - https://doc.rust-lang.org/stable/std/env/fn.current_exe.html#security
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/insecure-hashes.rs
+++ b/rust/lang/security/insecure-hashes.rs
@@ -1,0 +1,20 @@
+use md2::{Md2};
+use md4::{Md4};
+use md5::{Md5};
+use sha1::{Sha1};
+use sha2::{Sha256};
+
+// ruleid: insecure-hashes
+let mut hasher = Md2::new();
+
+// ruleid: insecure-hashes
+let mut hasher = Md4::new();
+
+// ruleid: insecure-hashes
+let mut hasher = Md5::new();
+
+// ruleid: insecure-hashes
+let mut hasher = Sha1::new();
+
+// ok: insecure-hashes
+let mut hasher = Sha256::new();

--- a/rust/lang/security/insecure-hashes.yml
+++ b/rust/lang/security/insecure-hashes.yml
@@ -1,0 +1,17 @@
+rules:
+  - id: insecure-hashes
+    message: Detected cryptographically insecure hashing function
+    pattern-either:
+      - pattern: "md2::Md2::new(...)"
+      - pattern: "md4::Md4::new(...)"
+      - pattern: "md5::Md5::new(...)"
+      - pattern: "sha1::Sha1::new(...)"
+    metadata:
+      references:
+        - https://github.com/RustCrypto/hashes
+        - https://docs.rs/md2/latest/md2/
+        - https://docs.rs/md4/latest/md4/
+        - https://docs.rs/md5/latest/md5/
+        - https://docs.rs/sha-1/latest/sha1/
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/insecure-hashes.yml
+++ b/rust/lang/security/insecure-hashes.yml
@@ -13,5 +13,13 @@ rules:
         - https://docs.rs/md4/latest/md4/
         - https://docs.rs/md5/latest/md5/
         - https://docs.rs/sha-1/latest/sha1/
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-328: Use of Weak Hash"
+      confidence: HIGH
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory: audit
     languages: [rust]
-    severity: INFO
+    severity: WARNING

--- a/rust/lang/security/reqwest-accept-invalid.rs
+++ b/rust/lang/security/reqwest-accept-invalid.rs
@@ -1,0 +1,30 @@
+use reqwest::header;
+
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .danger_accept_invalid_hostnames(true)
+    .build();
+
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .danger_accept_invalid_certs(true)
+    .build();
+
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .cookie_store(true)
+    .danger_accept_invalid_hostnames(true)
+    .build();
+
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .cookie_store(true)
+    .danger_accept_invalid_certs(true)
+    .build();
+
+// ok: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .build();

--- a/rust/lang/security/reqwest-accept-invalid.yml
+++ b/rust/lang/security/reqwest-accept-invalid.yml
@@ -1,0 +1,12 @@
+rules:
+  - id: reqwest-accept-invalid
+    message: Dangerously accepting invalid TLS information
+    pattern-either:
+      - pattern: reqwest::Client::builder(). ... .danger_accept_invalid_hostnames(true)
+      - pattern: reqwest::Client::builder(). ... .danger_accept_invalid_certs(true)
+    metadata:
+      references:
+        - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_hostnames
+        - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/reqwest-accept-invalid.yml
+++ b/rust/lang/security/reqwest-accept-invalid.yml
@@ -8,5 +8,13 @@ rules:
       references:
         - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_hostnames
         - https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs
+      technology:
+        - reqwest
+      category: security
+      cwe: "CWE-295: Improper Certificate Validation"
+      confidence: HIGH
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory: vuln
     languages: [rust]
-    severity: INFO
+    severity: WARNING

--- a/rust/lang/security/reqwest-set-sensitive.rs
+++ b/rust/lang/security/reqwest-set-sensitive.rs
@@ -1,0 +1,33 @@
+use reqwest::header;
+use reqwest::{blocking::Client, header::HeaderMap, header::HeaderValue, Url};
+
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+headers.insert(header::AUTHORIZATION, header);
+
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+headers.insert("Authorization", header);
+
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret").map_err(|e| {
+    Error::Generic(format!(
+        "Error"
+    ))
+});
+headers.insert(header::AUTHORIZATION, header);
+
+// Remove todo when Rust supports import equivalence
+// todoruleid: reqwest-set-sensitive
+let mut headers = HeaderMap::new();
+let header = HeaderValue::from_static("secret");
+headers.insert(header::AUTHORIZATION, header);
+
+// ok: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+header.set_sensitive(true);
+headers.insert(header::AUTHORIZATION, header);

--- a/rust/lang/security/reqwest-set-sensitive.yml
+++ b/rust/lang/security/reqwest-set-sensitive.yml
@@ -8,7 +8,7 @@ rules:
               ...
               let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
               ...
-              $HEADERS.insert(header::AUTHORIZATION, $HEADER_VALUE);
+              $HEADERS.insert($HEADER, $HEADER_VALUE);
           - pattern-not: |
               let mut $HEADERS = header::HeaderMap::new();
               ...
@@ -16,7 +16,7 @@ rules:
               ...
               $HEADER_VALUE.set_sensitive(true);
               ...
-              $HEADERS.insert(header::AUTHORIZATION, $HEADER_VALUE);
+              $HEADERS.insert($HEADER, $HEADER_VALUE);
           - metavariable-pattern:
               metavariable: $FROM_FUNC
               pattern-either:
@@ -25,29 +25,11 @@ rules:
                 - pattern: from_name
                 - pattern: from_bytes
                 - pattern: from_maybe_shared
-      - patterns:
-          - pattern: |
-              let mut $HEADERS = header::HeaderMap::new();
-              ...
-              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
-              ...
-              $HEADERS.insert("Authorization", $HEADER_VALUE);
-          - pattern-not: |
-              let mut $HEADERS = header::HeaderMap::new();
-              ...
-              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
-              ...
-              $HEADER_VALUE.set_sensitive(true);
-              ...
-              $HEADERS.insert("Authorization", $HEADER_VALUE);
           - metavariable-pattern:
-              metavariable: $FROM_FUNC
+              metavariable: $HEADER
               pattern-either:
-                - pattern: from_static
-                - pattern: from_str
-                - pattern: from_name
-                - pattern: from_bytes
-                - pattern: from_maybe_shared
+                - pattern: header::AUTHORIZATION
+                - pattern: '"Authorization"'
     metadata:
       references:
         - https://docs.rs/reqwest/latest/reqwest/header/struct.HeaderValue.html#method.set_sensitive

--- a/rust/lang/security/reqwest-set-sensitive.yml
+++ b/rust/lang/security/reqwest-set-sensitive.yml
@@ -1,35 +1,34 @@
 rules:
   - id: reqwest-set-sensitive
     message: Set sensitive flag on security headers with 'set_sensitive' to treat data with special care
-    pattern-either:
-      - patterns:
-          - pattern: |
-              let mut $HEADERS = header::HeaderMap::new();
-              ...
-              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
-              ...
-              $HEADERS.insert($HEADER, $HEADER_VALUE);
-          - pattern-not: |
-              let mut $HEADERS = header::HeaderMap::new();
-              ...
-              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
-              ...
-              $HEADER_VALUE.set_sensitive(true);
-              ...
-              $HEADERS.insert($HEADER, $HEADER_VALUE);
-          - metavariable-pattern:
-              metavariable: $FROM_FUNC
-              pattern-either:
-                - pattern: from_static
-                - pattern: from_str
-                - pattern: from_name
-                - pattern: from_bytes
-                - pattern: from_maybe_shared
-          - metavariable-pattern:
-              metavariable: $HEADER
-              pattern-either:
-                - pattern: header::AUTHORIZATION
-                - pattern: '"Authorization"'
+    patterns:
+      - pattern: |
+          let mut $HEADERS = header::HeaderMap::new();
+          ...
+          let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+          ...
+          $HEADERS.insert($HEADER, $HEADER_VALUE);
+      - pattern-not: |
+          let mut $HEADERS = header::HeaderMap::new();
+          ...
+          let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+          ...
+          $HEADER_VALUE.set_sensitive(true);
+          ...
+          $HEADERS.insert($HEADER, $HEADER_VALUE);
+      - metavariable-pattern:
+          metavariable: $FROM_FUNC
+          pattern-either:
+            - pattern: from_static
+            - pattern: from_str
+            - pattern: from_name
+            - pattern: from_bytes
+            - pattern: from_maybe_shared
+      - metavariable-pattern:
+          metavariable: $HEADER
+          pattern-either:
+            - pattern: header::AUTHORIZATION
+            - pattern: '"Authorization"'
     metadata:
       references:
         - https://docs.rs/reqwest/latest/reqwest/header/struct.HeaderValue.html#method.set_sensitive

--- a/rust/lang/security/reqwest-set-sensitive.yml
+++ b/rust/lang/security/reqwest-set-sensitive.yml
@@ -1,0 +1,55 @@
+rules:
+  - id: reqwest-set-sensitive
+    message: Set sensitive flag on security headers with 'set_sensitive' to treat data with special care
+    pattern-either:
+      - patterns:
+          - pattern: |
+              let mut $HEADERS = header::HeaderMap::new();
+              ...
+              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+              ...
+              $HEADERS.insert(header::AUTHORIZATION, $HEADER_VALUE);
+          - pattern-not: |
+              let mut $HEADERS = header::HeaderMap::new();
+              ...
+              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+              ...
+              $HEADER_VALUE.set_sensitive(true);
+              ...
+              $HEADERS.insert(header::AUTHORIZATION, $HEADER_VALUE);
+          - metavariable-pattern:
+              metavariable: $FROM_FUNC
+              pattern-either:
+                - pattern: from_static
+                - pattern: from_str
+                - pattern: from_name
+                - pattern: from_bytes
+                - pattern: from_maybe_shared
+      - patterns:
+          - pattern: |
+              let mut $HEADERS = header::HeaderMap::new();
+              ...
+              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+              ...
+              $HEADERS.insert("Authorization", $HEADER_VALUE);
+          - pattern-not: |
+              let mut $HEADERS = header::HeaderMap::new();
+              ...
+              let $HEADER_VALUE = <... header::HeaderValue::$FROM_FUNC(...) ...>;
+              ...
+              $HEADER_VALUE.set_sensitive(true);
+              ...
+              $HEADERS.insert("Authorization", $HEADER_VALUE);
+          - metavariable-pattern:
+              metavariable: $FROM_FUNC
+              pattern-either:
+                - pattern: from_static
+                - pattern: from_str
+                - pattern: from_name
+                - pattern: from_bytes
+                - pattern: from_maybe_shared
+    metadata:
+      references:
+        - https://docs.rs/reqwest/latest/reqwest/header/struct.HeaderValue.html#method.set_sensitive
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/reqwest-set-sensitive.yml
+++ b/rust/lang/security/reqwest-set-sensitive.yml
@@ -32,5 +32,13 @@ rules:
     metadata:
       references:
         - https://docs.rs/reqwest/latest/reqwest/header/struct.HeaderValue.html#method.set_sensitive
+      technology:
+        - reqwest
+      category: security
+      cwe: "CWE-921: Storage of Sensitive Data in a Mechanism without Access Control"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/rustls-dangerous.rs
+++ b/rust/lang/security/rustls-dangerous.rs
@@ -1,0 +1,19 @@
+use rustls::{RootCertStore, Certificate, ServerCertVerified, TLSError, ServerCertVerifier};
+
+let verifier = MyServerCertVerifie;
+
+// ok: rustls-dangerous
+let mut c1 = rustls::client::ClientConfig::new();
+
+// Remove todo when Rust supports direct module references
+// todoruleid: rustls-dangerous
+let mut c2 = rustls::client::DangerousClientConfig {cfg: &mut cfg};
+c2.set_certificate_verifier(verifier);
+
+let mut c3 = rustls::client::ClientConfig::new();
+// ruleid: rustls-dangerous
+c3.dangerous().set_certificate_verifier(verifier);
+
+// ruleid: rustls-dangerous
+let mut c4 = rustls::client::ClientConfig::dangerous(&mut ());
+c4.set_certificate_verifier(verifier);

--- a/rust/lang/security/rustls-dangerous.yml
+++ b/rust/lang/security/rustls-dangerous.yml
@@ -12,5 +12,13 @@ rules:
       references:
         - https://docs.rs/rustls/latest/rustls/client/struct.DangerousClientConfig.html
         - https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#method.dangerous
+      technology:
+        - rustls
+      category: security
+      cwe: "CWE-295: Improper Certificate Validation"
+      confidence: HIGH
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory: vuln
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/rustls-dangerous.yml
+++ b/rust/lang/security/rustls-dangerous.yml
@@ -1,0 +1,16 @@
+rules:
+  - id: rustls-dangerous
+    message: Dangerous client config used, ensure SSL verification
+    pattern-either:
+      - pattern: "rustls::client::DangerousClientConfig"
+      - pattern: "$CLIENT.dangerous().set_certificate_verifier(...)"
+      - pattern: |
+          let $CLIENT = rustls::client::ClientConfig::dangerous(...);
+          ...
+          $CLIENT.set_certificate_verifier(...);
+    metadata:
+      references:
+        - https://docs.rs/rustls/latest/rustls/client/struct.DangerousClientConfig.html
+        - https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#method.dangerous
+    languages: [rust]
+    severity: WARNING

--- a/rust/lang/security/ssl-verify-none.rs
+++ b/rust/lang/security/ssl-verify-none.rs
@@ -1,0 +1,11 @@
+use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+
+let mut connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
+
+// ruleid: ssl-verify-none
+connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+
+// ok: ssl-verify-none
+connector.builder_mut().set_verify(SSL_VERIFY_PEER);
+
+let openssl = OpenSsl::from(connector.build());

--- a/rust/lang/security/ssl-verify-none.yml
+++ b/rust/lang/security/ssl-verify-none.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: ssl-verify-none
+    message: SSL verification disabled, this allows for MitM attacks
+    pattern: "$BUILDER.set_verify(openssl::ssl::SSL_VERIFY_NONE)"
+    metadata:
+      references:
+        - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify
+    languages: [rust]
+    severity: WARNING

--- a/rust/lang/security/ssl-verify-none.yml
+++ b/rust/lang/security/ssl-verify-none.yml
@@ -5,5 +5,13 @@ rules:
     metadata:
       references:
         - https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_verify
+      technology:
+        - openssl
+      category: security
+      cwe: "CWE-295: Improper Certificate Validation"
+      confidence: HIGH
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory: vuln
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/temp-dir.rs
+++ b/rust/lang/security/temp-dir.rs
@@ -1,0 +1,4 @@
+use std::env;
+
+// ruleid: temp-dir
+let dir = env::temp_dir()

--- a/rust/lang/security/temp-dir.yml
+++ b/rust/lang/security/temp-dir.yml
@@ -1,0 +1,15 @@
+rules:
+  - id: temp-dir
+    message: |
+      temp_dir should not be used for security operations. From the docs:
+      'The temporary directory may be shared among users, or between processes
+      with different privileges; thus, the creation of any files or directories
+      in the temporary directory must use a secure method to create a uniquely
+      named file. Creating a file or directory with a fixed or predictable name
+      may result in “insecure temporary file” security vulnerabilities.'
+    pattern: "std::env::temp_dir()"
+    metadata:
+      references:
+        - https://doc.rust-lang.org/stable/std/env/fn.temp_dir.html
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/temp-dir.yml
+++ b/rust/lang/security/temp-dir.yml
@@ -1,6 +1,6 @@
 rules:
   - id: temp-dir
-    message: |
+    message: >-
       temp_dir should not be used for security operations. From the docs:
       'The temporary directory may be shared among users, or between processes
       with different privileges; thus, the creation of any files or directories

--- a/rust/lang/security/temp-dir.yml
+++ b/rust/lang/security/temp-dir.yml
@@ -11,5 +11,13 @@ rules:
     metadata:
       references:
         - https://doc.rust-lang.org/stable/std/env/fn.temp_dir.html
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-807: Reliance on Untrusted Inputs in a Security Decision"
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/unsafe-usage.rs
+++ b/rust/lang/security/unsafe-usage.rs
@@ -1,0 +1,5 @@
+// ruleid: unsafe-usage
+let pid = unsafe { libc::getpid() as u32 };
+
+// ok: unsafe-usage
+let pid = libc::getpid() as u32;

--- a/rust/lang/security/unsafe-usage.yml
+++ b/rust/lang/security/unsafe-usage.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: unsafe-usage
+    message: Detected 'unsafe' usage, please audit for secure usage
+    pattern: "unsafe { ... }"
+    metadata:
+      references:
+        - https://doc.rust-lang.org/std/keyword.unsafe.html
+    languages: [rust]
+    severity: INFO

--- a/rust/lang/security/unsafe-usage.yml
+++ b/rust/lang/security/unsafe-usage.yml
@@ -5,5 +5,13 @@ rules:
     metadata:
       references:
         - https://doc.rust-lang.org/std/keyword.unsafe.html
+      technology:
+        - rust
+      category: security
+      cwe: "CWE-242: Use of Inherently Dangerous Function"
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      subcategory: audit
     languages: [rust]
     severity: INFO


### PR DESCRIPTION
Hi all,

I'd like to contribute to bumping Rust from experimental -> beta (https://github.com/returntocorp/semgrep/issues/6545). Having some basic Rust rules is a prerequisite to that. These look like the first Rust rules, so I think this is a good start on basic security rules.

The `std` library rules come from searching the docs for "security" and "warning." The rest come from basic security ideas that apply to most languages/libraries.