### PR TITLE
Javascript Drizzle ORM Raw SQL

### DIFF
--- a/javascript/drizzle-orm/security/audit/ban-drizzle-sql-raw.js
+++ b/javascript/drizzle-orm/security/audit/ban-drizzle-sql-raw.js
@@ -1,0 +1,180 @@
+/**
+ * CommonJS import
+ */
+
+const { sql } = require("drizzle-orm");
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return sql.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return sql.execute(sql`select * from users where id = ${id}`);
+}
+  
+
+async function rawGetUserInTemplateLiteralsVariable(id) {
+   // ruleid: ban-drizzle-sql-raw
+  const query = `select * from users where id = ${id}`;
+  return sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperator(id) {
+  // ruleid: ban-drizzle-sql-raw
+  const query = "select * from users where id = " + id;
+  return sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperatorVariable(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return sql.raw("select * from users where id = " + id);
+}
+
+async function rawGetUserWithoutInjection() {
+  // ok: ban-drizzle-sql-raw
+  return sql.raw("select * from users where id = 1");
+}
+
+/**
+ * ESM import
+ */
+
+import { sql } from "drizzle-orm";
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return sql.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return sql.execute(sql`select * from users where id = ${id}`);
+}
+
+async function rawGetUserInTemplateLiteralsVariable(id) {
+   // ruleid: ban-drizzle-sql-raw
+  const query = `select * from users where id = ${id}`;
+  return sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperator(id) {
+  // ruleid: ban-drizzle-sql-raw
+  const query = "select * from users where id = " + id;
+  return sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperatorVariable(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return sql.raw("select * from users where id = " + id);
+}
+
+async function rawGetUserWithoutInjection() {
+  // ok: ban-drizzle-sql-raw
+  return sql.raw("select * from users where id = 1");
+}
+
+/**
+ * CommonJS import sql as SQL
+ */
+
+const { sql: SQL } = require("drizzle-orm");
+
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return SQL.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return SQL.execute(sql`select * from users where id = ${id}`);
+}
+
+/**
+ *  ESM import sql as SQL
+ */
+
+import { sql as SQL } from "drizzle-orm";
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return SQL.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return SQL.execute(sql`select * from users where id = ${id}`);
+}
+
+async function rawGetUserInTemplateLiteralsVariable(id) {
+   // ruleid: ban-drizzle-sql-raw
+  const query = `select * from users where id = ${id}`;
+  return SQL.raw(query);
+}
+
+async function rawGetUserWithPlusOperator(id) {
+  // ruleid: ban-drizzle-sql-raw
+  const query = "select * from users where id = " + id;
+  return SQL.raw(query);
+}
+
+async function rawGetUserWithPlusOperatorVariable(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return SQL.raw("select * from users where id = " + id);
+}
+
+async function rawGetUserWithoutInjection() {
+  // ok: ban-drizzle-sql-raw
+  return SQL.raw("select * from users where id = 1");
+}
+
+/**
+ * ESM import Drizzle
+ */
+
+import Drizzle from "drizzle-orm";
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return Drizzle.sql.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return Drizzle.sql.execute(sql`select * from users where id = ${id}`);
+}
+
+/**
+ * CommonJS import Drizzle
+ */
+
+const Drizzle = require("drizzle-orm");
+async function rawGetUser(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return Drizzle.sql.raw(`select * from users where id = ${id}`);
+}
+
+async function sqlEscapedGetUser(id) {
+  // ok: ban-drizzle-sql-raw
+  return Drizzle.sql.execute(sql`select * from users where id = ${id}`);
+}
+
+async function rawGetUserInTemplateLiteralsVariable(id) {
+   // ruleid: ban-drizzle-sql-raw
+  const query = `select * from users where id = ${id}`;
+  return Drizzle.sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperator(id) {
+  // ruleid: ban-drizzle-sql-raw
+  const query = "select * from users where id = " + id;
+  return Drizzle.sql.raw(query);
+}
+
+async function rawGetUserWithPlusOperatorVariable(id) {
+  // ruleid: ban-drizzle-sql-raw
+  return Drizzle.sql.raw("select * from users where id = " + id);
+}
+
+async function rawGetUserWithoutInjection() {
+  // ok: ban-drizzle-sql-raw
+  return Drizzle.sql.raw("select * from users where id = 1");
+}
+

--- a/javascript/drizzle-orm/security/audit/ban-drizzle-sql-raw.yaml
+++ b/javascript/drizzle-orm/security/audit/ban-drizzle-sql-raw.yaml
@@ -1,0 +1,91 @@
+rules:
+  - id: ban-drizzle-sql-raw
+    message:
+      Use of sql.raw() with SQL string concatenation is not allowed as it may lead to SQL injection.
+      Use parameterized queries with Drizzle's query builders instead.
+    fix: "/* Use sql`...` template literals or parameterized queries instead */"
+    metadata:
+      category: security
+      references:
+        - https://orm.drizzle.team/docs/sql#sqlraw
+      technology:
+        - javascript
+        - typescript
+        - drizzle-orm
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      subcategory:
+        - audit
+      likelihood: LOW
+      impact: HIGH
+      confidence: LOW
+    languages:
+      - javascript
+      - typescript
+    severity: ERROR
+    pattern-either:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  const { sql } = require('drizzle-orm')
+                  ...
+              - pattern-inside: |
+                  import { sql } from 'drizzle-orm'
+                  ...
+          - pattern-either:
+              - pattern: |
+                  sql.raw(`...${...}...`)
+              - pattern: |
+                  $QUERY = `...${...}...`
+                  ...
+                  sql.raw($QUERY)
+              - pattern: |
+                  $QUERY = $SQL + $VALUE
+                  ...
+                  sql.raw($QUERY)
+              - pattern: |
+                  sql.raw($SQL + $VALUE)
+
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import { sql as $ALIAS } from 'drizzle-orm'
+                  ...
+              - pattern-inside: |
+                  const { sql: $ALIAS } = require('drizzle-orm')
+                  ...
+          - pattern-either:
+              - pattern: |
+                  $ALIAS.raw(`...${...}...`)
+              - pattern: |
+                  $QUERY = `...${...}...`
+                  ...
+                  $ALIAS.raw($QUERY)
+              - pattern: |
+                  $QUERY = $SQL + $VALUE
+                  ...
+                  $ALIAS.raw($QUERY)
+              - pattern: |
+                  $ALIAS.raw($SQL + $VALUE)
+
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  const $DRIZZLE = require('drizzle-orm')
+                  ...
+              - pattern-inside: |
+                  import $DRIZZLE from 'drizzle-orm'
+                  ...
+          - pattern-either:
+              - pattern: |
+                  $DRIZZLE.sql.raw(`...${...}...`)
+              - pattern: |
+                  $QUERY = `...${...}...`
+                  ...
+                  $DRIZZLE.sql.raw($QUERY)
+              - pattern: |
+                  $QUERY = $SQL + $VALUE
+                  ...
+                  $DRIZZLE.sql.raw($QUERY)
+              - pattern: |
+                  $DRIZZLE.sql.raw($SQL + $VALUE)


### PR DESCRIPTION
This PR adds rules to prevent string concatenation in query when using Drizzle ORM `raw()` function.

Reference: https://orm.drizzle.team/docs/sql#sqlraw