### PR TITLE
Fix false positive for unquoted-attribute-var

### DIFF
--- a/generic/html-templates/security/unquoted-attribute-var.html
+++ b/generic/html-templates/security/unquoted-attribute-var.html
@@ -83,3 +83,21 @@
     </ul>
     <hr/>
 {% endfor %}
+
+<!-- ok: unquoted-attribute-var -->
+<span class="{{ isadmin ? 'admin' : 'user' }}"></span>
+
+<!-- ok: unquoted-attribute-var -->
+<span class="{{ isadmin ? "admin" : "user" }}"></span>
+
+<!-- ok: unquoted-attribute-var -->
+<span class='{{ isadmin ? "admin" : "user" }}'></span>
+
+<!-- ok: unquoted-attribute-var -->
+<span class='{{ isadmin ? 'admin' : 'user' }}'></span>
+
+<!-- ruleid: unquoted-attribute-var -->
+<span class={{ isadmin ? "admin" : "user" }}></span>
+
+<!-- ruleid: unquoted-attribute-var -->
+<span class={{ isadmin ? 'admin' : 'user' }}></span>

--- a/generic/html-templates/security/unquoted-attribute-var.yaml
+++ b/generic/html-templates/security/unquoted-attribute-var.yaml
@@ -33,7 +33,9 @@ rules:
   patterns:
   - pattern-inside: <$TAG ...>
   - pattern-not-inside: ="..."
+  - pattern-not-inside: ="{{ ... }}"
   - pattern-not-inside: ='...'
+  - pattern-not-inside: ='{{ ... }}'
   - pattern: '{{ ... }}'
   fix-regex:
     regex: '{{(.*?)}}'


### PR DESCRIPTION
If the expression itself contains the same quotes as that surround it, this rule would give a false positive.