### PR TITLE
Detect XSS in trigger_error

### DIFF
--- a/php/lang/security/injection/trigger-error.php
+++ b/php/lang/security/injection/trigger-error.php
@@ -1,0 +1,15 @@
+<?php
+
+$id = $_GET['id'];
+if (!is_numeric($id)) {
+    // ruleid: trigger-error
+    trigger_error("Not a number: $id");
+
+    // ok: trigger-error
+    trigger_error('Not a number: ' . htmlentities($id));
+
+    ini_set('display_errors', 0);
+    // ok: trigger-error
+    trigger_error("Not a number: $id");
+}
+

--- a/php/lang/security/injection/trigger-error.yaml
+++ b/php/lang/security/injection/trigger-error.yaml
@@ -1,0 +1,69 @@
+rules:
+- id: trigger-error
+  mode: taint
+  message: >-
+    The `$message` parameter to `trigger_error` is not HTML-encoded.
+    If the error is displayed in a browser, this risks a cross-site
+    scripting vulnerability. Escape the message with `htmlentities()`
+    or disable `display_errors`.
+  languages: [php]
+  severity: WARNING
+  pattern-sources:
+  - pattern: $_REQUEST
+  - pattern: $_GET
+  - pattern: $_POST
+  pattern-sinks:
+    - patterns:
+      - pattern: trigger_error(...)
+      - pattern-not-inside: |
+          ini_set('display_errors', 0);
+          ...
+  pattern-sanitizers:
+  - pattern: htmlentities(...)
+  - pattern: htmlspecialchars(...)
+  - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
+  # Wordpress Escapes
+  - pattern: esc_html(...)
+  - pattern: esc_attr(...)
+  - pattern: wp_kses(...)
+  # Laravel Escapes
+  - pattern: e(...)
+  # Symfony Escapes
+  - pattern: twig_escape_filter(...)
+  # CodeIgniter Escapes
+  - pattern: xss_clean(...)
+  - pattern: html_escape(...)
+  # Drupal Escapes
+  - pattern: Html::escape(...)
+  - pattern: Xss::filter(...)
+  # Magento Escapes
+  - pattern: escapeHtml(...)
+  # Laminas Escapes
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtmlAttr(...)
+  metadata:
+    technology:
+    - php
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    references:
+    - https://www.php.net/trigger_error
+    - https://bugs.php.net/bug.php?id=77074
+    - https://www.php.net/manual/en/function.htmlentities.php
+    - https://www.php.net/manual/en/reserved.variables.request.php
+    - https://www.php.net/manual/en/reserved.variables.post.php
+    - https://www.php.net/manual/en/reserved.variables.get.php
+    - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW


### PR DESCRIPTION
The message passed to trigger_error is not HTML encoded by default, and can be displayed in the browser if display_errors is on.