### PR TITLE
feat(python/django): add rule to detect missing SecurityMiddleware

### DIFF
--- a/python/django/security/audit/missing-security-middleware.py
+++ b/python/django/security/audit/missing-security-middleware.py
@@ -1,0 +1,16 @@
+# Test file for django-missing-security-middleware rule
+
+# ruleid: django-missing-security-middleware
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+]
+
+# ok: django-missing-security-middleware
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+]

--- a/python/django/security/audit/missing-security-middleware.yaml
+++ b/python/django/security/audit/missing-security-middleware.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: django-missing-security-middleware
+    patterns:
+      - pattern: |
+          MIDDLEWARE = [...]
+      - pattern-not: |
+          MIDDLEWARE = [..., "django.middleware.security.SecurityMiddleware", ...]
+    message: >-
+      Django's SecurityMiddleware is missing from the MIDDLEWARE setting.
+      SecurityMiddleware provides several security enhancements including
+      HTTPS redirection, HSTS headers, and content type sniffing protection.
+      For ecommerce and other sensitive applications handling payment or
+      personal data, this middleware is critical for PCI-DSS compliance
+      and general web application security. Add
+      'django.middleware.security.SecurityMiddleware' to your MIDDLEWARE list,
+      ideally as the first entry.
+    languages:
+      - python
+    severity: WARNING
+    metadata:
+      category: security
+      technology:
+        - django
+      owasp:
+        - A05:2021 - Security Misconfiguration
+      cwe:
+        - "CWE-16: Configuration"
+      references:
+        - https://docs.djangoproject.com/en/stable/ref/middleware/#django.middleware.security.SecurityMiddleware
+        - https://docs.djangoproject.com/en/stable/topics/security/
+      subcategory:
+        - audit
+      likelihood: MEDIUM
+      impact: MEDIUM
+      confidence: MEDIUM
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      vulnerability_class:
+        - Misconfiguration


### PR DESCRIPTION
## Summary

This PR adds a new Semgrep rule to detect when Django's SecurityMiddleware is missing from the MIDDLEWARE setting in Django applications.

## Problem

Django's SecurityMiddleware provides several critical security protections:
- HTTPS redirection (SECURE_SSL_REDIRECT)
- HTTP Strict Transport Security (HSTS) headers
- Content type sniffing protection (X-Content-Type-Options)
- Cross-site scripting filter (X-XSS-Protection)

When SecurityMiddleware is absent, none of these protections are active, leaving web applications — particularly ecommerce applications handling payment and personal data - exposed to common web attacks and non-compliant with PCI-DSS requirements.

This misconfiguration is common and does not currently have a rule in the Semgrep registry.

## Changes

- Added `missing-security-middleware.yaml` - rule targeting Python/Django settings files where MIDDLEWARE list does not include SecurityMiddleware
- Added `missing-security-middleware.py` - test file with positive case   (missing middleware, should trigger) and negative case 
  (middleware present, should not trigger)

## References

- https://docs.djangoproject.com/en/stable/ref/middleware/#django.middleware.security.SecurityMiddleware
- https://docs.djangoproject.com/en/stable/topics/security/
- OWASP A05:2021 - Security Misconfiguration
- CWE-16: Configuration