### PR TITLE
Add 4 Laravel security rules: raw SQL, open redirect, mass assignment, weak hashing

### DIFF
--- a/php/laravel/security/laravel-mass-assignment-fillable-star.php
+++ b/php/laravel/security/laravel-mass-assignment-fillable-star.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class VulnerableUser extends Model
+{
+    /**
+     * Wildcard fillable - allows mass assignment of ALL attributes.
+     */
+    // ruleid: laravel-mass-assignment-fillable-star
+    protected $fillable = ['*'];
+}
+
+class SafeUser extends Model
+{
+    /**
+     * Only specific fields are mass-assignable.
+     */
+    // ok: laravel-mass-assignment-fillable-star
+    protected $fillable = ['name', 'email', 'password'];
+}
+
+class AnotherSafeModel extends Model
+{
+    /**
+     * Using guarded to block specific fields is also acceptable.
+     */
+    // ok: laravel-mass-assignment-fillable-star
+    protected $fillable = ['title', 'body', 'slug'];
+}
+?>

--- a/php/laravel/security/laravel-mass-assignment-fillable-star.php
+++ b/php/laravel/security/laravel-mass-assignment-fillable-star.php
@@ -28,6 +28,6 @@ class AnotherSafeModel extends Model
      * Using guarded to block specific fields is also acceptable.
      */
     // ok: laravel-mass-assignment-fillable-star
-    protected $fillable = ['title', 'body', 'slug'];
+    protected $guarded = ['id', 'is_admin'];
 }
 ?>

--- a/php/laravel/security/laravel-mass-assignment-fillable-star.yaml
+++ b/php/laravel/security/laravel-mass-assignment-fillable-star.yaml
@@ -1,0 +1,37 @@
+rules:
+- id: laravel-mass-assignment-fillable-star
+  patterns:
+  - pattern: |
+      $fillable = ['*'];
+  - pattern-inside: |
+      class $CLASS extends Model {
+        ...
+      }
+  message: >-
+    Setting `$fillable` to `['*']` allows mass assignment of all attributes on this
+    Eloquent model, including sensitive fields like `role`, `is_admin`, or `password`.
+    This defeats Laravel's built-in mass assignment protection and can allow attackers
+    to modify unintended columns. Explicitly list only the fields that should be
+    mass-assignable in the `$fillable` array.
+  languages:
+  - php
+  severity: ERROR
+  metadata:
+    category: security
+    cwe:
+    - 'CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes'
+    owasp:
+    - A08:2021 - Software and Data Integrity Failures
+    - A08:2025 - Software or Data Integrity Failures
+    technology:
+    - php
+    - laravel
+    - eloquent
+    references:
+    - https://laravel.com/docs/10.x/eloquent#mass-assignment
+    - https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    confidence: HIGH

--- a/php/laravel/security/laravel-raw-db-statement.php
+++ b/php/laravel/security/laravel-raw-db-statement.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
+
+function vulnerable_statement(Request $request) {
+    $table = $request->input('table');
+
+    // ruleid: laravel-raw-db-statement
+    DB::statement("DROP TABLE " . $table);
+}
+
+function vulnerable_select(Request $request) {
+    $name = $request->input('name');
+
+    // ruleid: laravel-raw-db-statement
+    DB::select("SELECT * FROM users WHERE name = '$name'");
+}
+
+function vulnerable_raw(Request $request) {
+    $column = $request->input('sort');
+
+    // ruleid: laravel-raw-db-statement
+    DB::raw("ORDER BY " . $column);
+}
+
+function vulnerable_insert(Request $request) {
+    $value = $request->input('value');
+
+    // ruleid: laravel-raw-db-statement
+    DB::insert("INSERT INTO logs (entry) VALUES ('$value')");
+}
+
+function vulnerable_superglobal() {
+    $id = $_GET['id'];
+
+    // ruleid: laravel-raw-db-statement
+    DB::select("SELECT * FROM users WHERE id = " . $id);
+}
+
+function safe_parameterized(Request $request) {
+    $name = $request->input('name');
+
+    // ok: laravel-raw-db-statement
+    DB::select("SELECT * FROM users WHERE name = ?", [$name]);
+}
+
+function safe_statement_parameterized(Request $request) {
+    $id = $request->input('id');
+
+    // ok: laravel-raw-db-statement
+    DB::statement("UPDATE users SET active = 1 WHERE id = ?", [$id]);
+}
+
+function safe_static_query() {
+    // ok: laravel-raw-db-statement
+    DB::select("SELECT * FROM users WHERE active = 1");
+}
+
+function safe_cast(Request $request) {
+    $id = (int) $request->input('id');
+
+    // ok: laravel-raw-db-statement
+    DB::select("SELECT * FROM users WHERE id = " . $id);
+}
+?>

--- a/php/laravel/security/laravel-raw-db-statement.yaml
+++ b/php/laravel/security/laravel-raw-db-statement.yaml
@@ -20,9 +20,13 @@ rules:
     - pattern-either:
       - pattern: intval(...)
       - pattern: (int) $X
+      - pattern: (integer) $X
       - pattern: (float) $X
+      - pattern: (double) $X
       - pattern: (bool) $X
-      - pattern: htmlspecialchars(...)
+      - pattern: (boolean) $X
+      - pattern: floatval(...)
+      - pattern: boolval(...)
   pattern-sinks:
   - patterns:
     - pattern-either:

--- a/php/laravel/security/laravel-raw-db-statement.yaml
+++ b/php/laravel/security/laravel-raw-db-statement.yaml
@@ -1,0 +1,61 @@
+rules:
+- id: laravel-raw-db-statement
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: $_GET
+      - pattern: $_POST
+      - pattern: $_COOKIE
+      - pattern: $_REQUEST
+      - pattern: $_SERVER
+  - patterns:
+    - pattern-either:
+      - pattern: $request->input(...)
+      - pattern: $request->get(...)
+      - pattern: $request->query(...)
+      - pattern: $request->post(...)
+  pattern-sanitizers:
+  - patterns:
+    - pattern-either:
+      - pattern: intval(...)
+      - pattern: htmlspecialchars(...)
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: DB::statement($QUERY, ...)
+      - pattern: DB::select($QUERY, ...)
+      - pattern: DB::insert($QUERY, ...)
+      - pattern: DB::update($QUERY, ...)
+      - pattern: DB::delete($QUERY, ...)
+      - pattern: DB::raw($QUERY)
+    - focus-metavariable: $QUERY
+  message: >-
+    User-controlled input flows into a raw database statement via `DB::statement()`,
+    `DB::select()`, `DB::raw()`, or similar methods without parameterization.
+    This can lead to SQL injection. Use parameterized queries with bound
+    parameters instead (e.g., `DB::select('SELECT * FROM users WHERE id = ?', [$id])`).
+  languages:
+  - php
+  severity: ERROR
+  metadata:
+    category: security
+    cwe:
+    - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    - A05:2025 - Injection
+    technology:
+    - php
+    - laravel
+    references:
+    - https://laravel.com/docs/10.x/database#running-queries
+    - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    confidence: MEDIUM

--- a/php/laravel/security/laravel-raw-db-statement.yaml
+++ b/php/laravel/security/laravel-raw-db-statement.yaml
@@ -19,6 +19,9 @@ rules:
   - patterns:
     - pattern-either:
       - pattern: intval(...)
+      - pattern: (int) $X
+      - pattern: (float) $X
+      - pattern: (bool) $X
       - pattern: htmlspecialchars(...)
   pattern-sinks:
   - patterns:

--- a/php/laravel/security/laravel-unvalidated-redirect.php
+++ b/php/laravel/security/laravel-unvalidated-redirect.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+
+function vulnerable_redirect_input(Request $request) {
+    $url = $request->input('redirect_url');
+
+    // ruleid: laravel-unvalidated-redirect
+    return redirect($request->input('redirect_url'));
+}
+
+function vulnerable_redirect_get(Request $request) {
+    // ruleid: laravel-unvalidated-redirect
+    return redirect($request->get('url'));
+}
+
+function vulnerable_redirect_query(Request $request) {
+    // ruleid: laravel-unvalidated-redirect
+    return redirect($request->query('next'));
+}
+
+function vulnerable_facade_redirect(Request $request) {
+    // ruleid: laravel-unvalidated-redirect
+    return Redirect::to($request->input('url'));
+}
+
+function vulnerable_redirect_to(Request $request) {
+    // ruleid: laravel-unvalidated-redirect
+    return redirect()->to($request->get('return_url'));
+}
+
+function vulnerable_superglobal() {
+    // ruleid: laravel-unvalidated-redirect
+    return redirect($_GET['url']);
+}
+
+function vulnerable_post_superglobal() {
+    // ruleid: laravel-unvalidated-redirect
+    return Redirect::to($_POST['redirect']);
+}
+
+function safe_static_redirect() {
+    // ok: laravel-unvalidated-redirect
+    return redirect('/dashboard');
+}
+
+function safe_route_redirect() {
+    // ok: laravel-unvalidated-redirect
+    return redirect()->route('home');
+}
+
+function safe_intended_redirect() {
+    // ok: laravel-unvalidated-redirect
+    return redirect()->intended('/dashboard');
+}
+
+function safe_back_redirect() {
+    // ok: laravel-unvalidated-redirect
+    return redirect()->back();
+}
+?>

--- a/php/laravel/security/laravel-unvalidated-redirect.yaml
+++ b/php/laravel/security/laravel-unvalidated-redirect.yaml
@@ -47,7 +47,7 @@ rules:
     - "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
     owasp:
     - A01:2021 - Broken Access Control
-    - A04:2025 - Broken Access Control
+    - A01:2025 - Broken Access Control
     technology:
     - php
     - laravel

--- a/php/laravel/security/laravel-unvalidated-redirect.yaml
+++ b/php/laravel/security/laravel-unvalidated-redirect.yaml
@@ -1,0 +1,61 @@
+rules:
+- id: laravel-unvalidated-redirect
+  patterns:
+  - pattern-either:
+    - pattern: |
+        redirect($request->input(...))
+    - pattern: |
+        redirect($request->get(...))
+    - pattern: |
+        redirect($request->query(...))
+    - pattern: |
+        Redirect::to($request->input(...))
+    - pattern: |
+        Redirect::to($request->get(...))
+    - pattern: |
+        Redirect::to($request->query(...))
+    - pattern: |
+        redirect()->to($request->input(...))
+    - pattern: |
+        redirect()->to($request->get(...))
+    - pattern: |
+        redirect()->to($request->query(...))
+    - pattern: |
+        redirect($_GET[...])
+    - pattern: |
+        redirect($_POST[...])
+    - pattern: |
+        redirect($_REQUEST[...])
+    - pattern: |
+        Redirect::to($_GET[...])
+    - pattern: |
+        Redirect::to($_POST[...])
+    - pattern: |
+        Redirect::to($_REQUEST[...])
+  message: >-
+    User-controlled input is passed directly to a redirect function without validation.
+    This allows attackers to redirect users to malicious external sites (open redirect),
+    which can be used for phishing or credential theft. Validate the redirect target
+    against an allowlist of permitted URLs or use `redirect()->intended()` with a
+    safe default.
+  languages:
+  - php
+  severity: WARNING
+  metadata:
+    category: security
+    cwe:
+    - "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+    owasp:
+    - A01:2021 - Broken Access Control
+    - A04:2025 - Broken Access Control
+    technology:
+    - php
+    - laravel
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+    - https://laravel.com/docs/10.x/redirects
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM

--- a/php/laravel/security/laravel-weak-password-hash.php
+++ b/php/laravel/security/laravel-weak-password-hash.php
@@ -14,9 +14,21 @@ function vulnerable_sha1_password($user_password) {
     return $hashed;
 }
 
-function vulnerable_crypt_password($password) {
+function vulnerable_crypt_md5_password($password) {
     // ruleid: laravel-weak-password-hash
-    $hashed = crypt($password, '$2y$10$salt');
+    $hashed = crypt($password, '$1$saltsalt$');
+    return $hashed;
+}
+
+function vulnerable_crypt_sha256_password($password) {
+    // ruleid: laravel-weak-password-hash
+    $hashed = crypt($password, '$5$rounds=5000$saltsaltsalt$');
+    return $hashed;
+}
+
+function safe_crypt_bcrypt($password) {
+    // ok: laravel-weak-password-hash
+    $hashed = crypt($password, '$2y$10$abcdefghijklmnopqrstuu');
     return $hashed;
 }
 

--- a/php/laravel/security/laravel-weak-password-hash.php
+++ b/php/laravel/security/laravel-weak-password-hash.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\Hash;
+
+function vulnerable_md5_password($password) {
+    // ruleid: laravel-weak-password-hash
+    $hashed = md5($password);
+    return $hashed;
+}
+
+function vulnerable_sha1_password($user_password) {
+    // ruleid: laravel-weak-password-hash
+    $hashed = sha1($user_password);
+    return $hashed;
+}
+
+function vulnerable_crypt_password($password) {
+    // ruleid: laravel-weak-password-hash
+    $hashed = crypt($password, '$2y$10$salt');
+    return $hashed;
+}
+
+function vulnerable_md5_pass($pass) {
+    // ruleid: laravel-weak-password-hash
+    $hashed = md5($pass);
+    return $hashed;
+}
+
+function safe_hash_make($password) {
+    // ok: laravel-weak-password-hash
+    $hashed = Hash::make($password);
+    return $hashed;
+}
+
+function safe_bcrypt($password) {
+    // ok: laravel-weak-password-hash
+    $hashed = bcrypt($password);
+    return $hashed;
+}
+
+function safe_md5_non_password($email) {
+    // ok: laravel-weak-password-hash
+    $gravatar = md5($email);
+    return $gravatar;
+}
+
+function safe_sha1_non_password($filename) {
+    // ok: laravel-weak-password-hash
+    $hash = sha1($filename);
+    return $hash;
+}
+?>

--- a/php/laravel/security/laravel-weak-password-hash.yaml
+++ b/php/laravel/security/laravel-weak-password-hash.yaml
@@ -1,0 +1,38 @@
+rules:
+- id: laravel-weak-password-hash
+  patterns:
+  - pattern-either:
+    - pattern: md5($PASSWORD)
+    - pattern: sha1($PASSWORD)
+    - pattern: crypt($PASSWORD, ...)
+  - metavariable-regex:
+      metavariable: $PASSWORD
+      regex: (?i).*pass(word)?.*
+  message: >-
+    A weak hashing function (`md5`, `sha1`, or `crypt`) is used on a variable whose
+    name suggests it contains a password. These algorithms are not designed for password
+    hashing and are vulnerable to brute-force and rainbow table attacks.
+    Use Laravel's `Hash::make()` or the `bcrypt()` helper instead, which use bcrypt
+    with a secure cost factor by default.
+  languages:
+  - php
+  severity: ERROR
+  metadata:
+    category: security
+    cwe:
+    - 'CWE-328: Use of Weak Hash'
+    - 'CWE-916: Use of Password Hash With Insufficient Computational Effort'
+    owasp:
+    - A02:2021 - Cryptographic Failures
+    - A01:2025 - Cryptographic Failures
+    technology:
+    - php
+    - laravel
+    references:
+    - https://laravel.com/docs/10.x/hashing
+    - https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    confidence: MEDIUM

--- a/php/laravel/security/laravel-weak-password-hash.yaml
+++ b/php/laravel/security/laravel-weak-password-hash.yaml
@@ -32,7 +32,7 @@ rules:
     - 'CWE-916: Use of Password Hash With Insufficient Computational Effort'
     owasp:
     - A02:2021 - Cryptographic Failures
-    - A01:2025 - Cryptographic Failures
+    - A04:2025 - Cryptographic Failures
     technology:
     - php
     - laravel

--- a/php/laravel/security/laravel-weak-password-hash.yaml
+++ b/php/laravel/security/laravel-weak-password-hash.yaml
@@ -4,16 +4,24 @@ rules:
   - pattern-either:
     - pattern: md5($PASSWORD)
     - pattern: sha1($PASSWORD)
-    - pattern: crypt($PASSWORD, ...)
+    - pattern: hash("md5", $PASSWORD)
+    - pattern: hash("sha1", $PASSWORD)
+    - patterns:
+      - pattern: crypt($PASSWORD, $SALT)
+      - metavariable-regex:
+          metavariable: $SALT
+          regex: ^["']\$(1|5|6)\$.*
   - metavariable-regex:
       metavariable: $PASSWORD
       regex: (?i).*pass(word)?.*
   message: >-
-    A weak hashing function (`md5`, `sha1`, or `crypt`) is used on a variable whose
-    name suggests it contains a password. These algorithms are not designed for password
-    hashing and are vulnerable to brute-force and rainbow table attacks.
-    Use Laravel's `Hash::make()` or the `bcrypt()` helper instead, which use bcrypt
-    with a secure cost factor by default.
+    A weak hashing function (`md5`, `sha1`, or `crypt` with an MD5/SHA-2 legacy
+    salt format) is used on a variable whose name suggests it contains a password.
+    These algorithms are not designed for password hashing and are vulnerable to
+    brute-force and rainbow-table attacks. Use Laravel's `Hash::make()` or the
+    `bcrypt()` helper instead, which use bcrypt with a secure cost factor by default.
+    Note: `crypt()` with a `$2y$` (bcrypt) salt is acceptable but prefer Laravel's
+    Hash facade.
   languages:
   - php
   severity: ERROR


### PR DESCRIPTION
## Summary

Adds 4 new security rules for Laravel/PHP applications with corresponding test files:

| # | Rule | Severity | CWE | Detection |
|---|------|----------|-----|-----------|
| 1 | `laravel-raw-db-statement` | ERROR | CWE-89 | Tainted user input in `DB::statement/select/insert/update/delete/raw` |
| 2 | `laravel-unvalidated-redirect` | WARNING | CWE-601 | Open redirect via `redirect()` with unvalidated `$request->input()` |
| 3 | `laravel-mass-assignment-fillable-star` | ERROR | CWE-915 | `$fillable = ['*']` wildcard bypassing mass assignment protection |
| 4 | `laravel-weak-password-hash` | ERROR | CWE-328 | `md5()`/`sha1()`/`crypt()` for passwords instead of `Hash::make()` |

Each rule includes a `.php` test file with `ruleid:` and `ok:` annotations.

## Context

The existing Laravel security ruleset has 11 rules. These additions cover critical gaps:

- **Rule 1** complements existing `laravel-sql-injection` (which covers `whereRaw`/`orderByRaw`) by detecting `DB::` facade methods (`statement`, `select`, `insert`, `update`, `delete`, `raw`) with tainted input. Includes sanitizers for type casting (`intval`, `(int)`).
- **Rule 2** is entirely new - no open redirect detection existed for Laravel.
- **Rule 3** complements `laravel-dangerous-model-construction` (which catches `$guarded = []`) by detecting the `$fillable = ['*']` wildcard variant.
- **Rule 4** is entirely new - detects insecure password hashing in authentication contexts.

## Test Plan

- [ ] Run `semgrep --test php/laravel/security/` to validate all rule/test pairs pass
- [ ] Verify each `ruleid:` annotation triggers and each `ok:` annotation does not
- [ ] Test against open-source Laravel applications for false positive rate