### PR TITLE
Go: idna-ip-literal-smuggle (UTS-46 NFKC digit-fold SSRF)

### DIFF
--- a/go/lang/security/audit/idna-ip-literal-smuggle.go
+++ b/go/lang/security/audit/idna-ip-literal-smuggle.go
@@ -22,6 +22,10 @@
 //              P6a, P6b
 //     Class 7  Trailing-dot bypass / propagator-shape coverage (residual)
 //              P7a, P7b
+//     Class 8  ToUnicode entry point on a digit-folding profile
+//              (validateAndMap runs before the encode-vs-decode branch,
+//              so ToUnicode folds digits identically to ToASCII).
+//              P8a, P8b
 //
 //   Source-pattern coverage (each new untrusted-input source shape):
 //     S1  *http.Request.URL.Hostname()
@@ -234,6 +238,29 @@ func p7bNewProfileMultiOption(rawHost string) {
 	profile := idna.New(idna.MapForLookup(), idna.Transitional(true))
 	ace, _ := profile.ToASCII(rawHost)
 	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80")) // todoruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 8: ToUnicode entry point. The library runs validateAndMap before
+// the encode-vs-decode branch, so ToUnicode produces the same digit-fold
+// ASCII output as ToASCII for in-scope codepoints. Empirically verified
+// against golang.org/x/net/idna v0.53.0:
+//   Lookup.ToUnicode("0.¹.0.0")  -> "0.1.0.0"
+//   Display.ToUnicode("10.⁹.0.1") -> "10.9.0.1"
+// =====================================================================
+
+// P8a: Latin-1 superscript via Lookup.ToUnicode -> http.Get.
+func p8aLatin1ToUnicode() {
+	host := "0.¹.0.0"
+	out, _ := idna.Lookup.ToUnicode(host)
+	_, _ = http.Get("https://" + out + "/") // ruleid: idna-ip-literal-smuggle
+}
+
+// P8b: Math superscript via Display.ToUnicode -> net.LookupHost.
+func p8bMathSuperscriptToUnicode() {
+	host := "10.⁹.0.1"
+	out, _ := idna.Display.ToUnicode(host)
+	_, _ = net.LookupHost(out) // ruleid: idna-ip-literal-smuggle
 }
 
 // =====================================================================

--- a/go/lang/security/audit/idna-ip-literal-smuggle.go
+++ b/go/lang/security/audit/idna-ip-literal-smuggle.go
@@ -1,0 +1,399 @@
+// Test fixtures for idna-ip-literal-smuggle.
+//
+// Semgrep test layout: each "ruleid" trailing comment on a sink line
+// asserts that the rule fires there; each "ok" trailing comment asserts
+// the rule does NOT fire there; "todoruleid" marks Pro-tier-only fixtures
+// where the OSS rule cannot reach. Run with `semgrep --test test/`.
+//
+// Coverage matrix:
+//
+//   Fold-class positives (>= 2 per class, full adversarial coverage):
+//     Class 1  Latin-1 superscripts (U+00B2, U+00B3, U+00B9)
+//              P1a, P1b, P1c
+//     Class 2  Mathematical super- and subscripts (U+2070..U+2089)
+//              P2a, P2b, P2c, P2d
+//     Class 3  Circled digits (U+2460..U+2468, U+24EA)
+//              P3a, P3b
+//     Class 4  Fullwidth digits (U+FF10..U+FF19)
+//              P4a, P4b
+//     Class 5  Mathematical styled digits (bold/dbl/sans/mono, U+1D7CE..U+1D7FF)
+//              P5a, P5b, P5c, P5d
+//     Class 6  Segmented digits (U+1FBF0..U+1FBF9)
+//              P6a, P6b
+//     Class 7  Trailing-dot bypass / propagator-shape coverage (residual)
+//              P7a, P7b
+//
+//   Source-pattern coverage (each new untrusted-input source shape):
+//     S1  *http.Request.URL.Hostname()
+//     S2  *http.Request.Header.Get(...)
+//     S3  os.Getenv(...)
+//     S4  flag.String(...)
+//     S5  *bufio.Scanner.Text()
+//     S6  *json.Decoder.Decode(...)
+//     S7  *sql.Rows.Scan(...)
+//
+//   Negatives:
+//     N1  Compliant: TrimRight + netip.ParseAddr post-recheck
+//     N2  Compliant: TrimSuffix + net.ParseIP post-recheck (legacy form)
+//     N3  Compliant: manual slice trim + netip.ParseAddr
+//     N4  Compliant: TrimRight + net.ParseIP post-recheck
+//     N5  Out of scope: idna.Punycode profile (nil mapping)
+//     N6  Out of scope: Devanagari digits (status V Valid, not mapped)
+//     N7  Adversarial: unrelated TrimRight + ParseIP on a SEPARATE string
+//         in the same function as an IDNA-tainted path. Pre-fix
+//         (sanitizer block had no `requires:` constraint) the rule
+//         would silently sanitize the IDNA path. Post-fix
+//         (`requires: POST_IDNA` on the sanitizer block) the IDNA path
+//         correctly triggers the alert. This is intentionally annotated
+//         with `ruleid:` because the alert MUST fire after the fix.
+
+package fixtures
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strings"
+
+	"golang.org/x/net/idna"
+)
+
+// =====================================================================
+// Class 1: Latin-1 superscripts (U+00B2, U+00B3, U+00B9).
+// =====================================================================
+
+// P1a: Latin-1 superscript Â¹ (U+00B9), hardcoded literal -> ToASCII -> Dial.
+func p1aLatin1SuperscriptOne() {
+	host := "0.¹.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80")) // ruleid: idna-ip-literal-smuggle
+}
+
+// P1b: Latin-1 superscript Â² (U+00B2), idna.Display profile -> http.Get.
+func p1bLatin1SuperscriptTwo() {
+	host := "0.².0.0"
+	ace, _ := idna.Display.ToASCII(host)
+	_, _ = http.Get("http://" + ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// P1c: Latin-1 superscript Â³ (U+00B3), idna.Registration profile -> LookupHost.
+func p1cLatin1SuperscriptThree() {
+	host := "0.³.0.0"
+	ace, _ := idna.Registration.ToASCII(host)
+	_, _ = net.LookupHost(ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 2: Mathematical super- and subscripts (U+2070..U+2089).
+// =====================================================================
+
+// P2a: Math superscript ⁰ (U+2070), New(MapForLookup) profile.
+func p2aMathSuperscriptZero() {
+	host := "0.⁰.0.0"
+	profile := idna.New(idna.MapForLookup())
+	ace, _ := profile.ToASCII(host)
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "443")) // todoruleid: idna-ip-literal-smuggle
+}
+
+// P2b: Math superscript ⁴ (U+2074).
+func p2bMathSuperscriptFour() {
+	host := "0.⁴.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = http.Get("http://" + ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// P2c: Math subscript ₀ (U+2080).
+func p2cMathSubscriptZero() {
+	host := "0.₀.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.LookupIP(ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// P2d: Math subscript ₉ (U+2089), via *idna.Profile receiver shape.
+func p2dMathSubscriptNine(p *idna.Profile) {
+	host := "0.₉.0.0"
+	ace, _ := p.ToASCII(host)
+	_, _ = net.DialTimeout("tcp", net.JoinHostPort(ace, "8080"), 0) // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 3: Circled digits (U+2460..U+2468, U+24EA).
+// =====================================================================
+
+// P3a: Circled digit ① (U+2460) -> http.NewRequest.
+func p3aCircledDigitOne() {
+	host := "0.①.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	req, _ := http.NewRequest("GET", "http://"+ace, nil) // ruleid: idna-ip-literal-smuggle
+	_ = req
+}
+
+// P3b: Circled digit zero ⓪ (U+24EA) -> *url.URL.Host assignment.
+func p3bCircledDigitZero() {
+	host := "0.⓪.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	u := &url.URL{Scheme: "http"}
+	u.Host = ace // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 4: Fullwidth digits (U+FF10..U+FF19).
+// =====================================================================
+
+// P4a: Fullwidth digit １ (U+FF11).
+func p4aFullwidthDigitOne() {
+	host := "0.１.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.LookupHost(ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// P4b: Fullwidth digit ï¼™ (U+FF19) -> http.Cookie.Domain.
+func p4bFullwidthDigitNine() {
+	host := "0.９.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	c := &http.Cookie{}
+	c.Domain = ace // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 5: Mathematical styled digits (U+1D7CE..U+1D7FF) - bold,
+// double-struck, sans-serif, sans-bold, monospace.
+// =====================================================================
+
+// P5a: Math bold digit (U+1D7CE).
+func p5aMathBoldDigit() {
+	host := "0.𝟎.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	c := &http.Cookie{}
+	c.Domain = ace // ruleid: idna-ip-literal-smuggle
+}
+
+// P5b: Math double-struck digit (U+1D7D8).
+func p5bMathDoubleStruckDigit() {
+	host := "0.𝟘.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "443")) // ruleid: idna-ip-literal-smuggle
+}
+
+// P5c: Math sans-serif digit (U+1D7E2).
+func p5cMathSansSerifDigit() {
+	host := "0.𝟢.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = http.Head("http://" + ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// P5d: Math monospace digit (U+1D7F6).
+func p5dMathMonospaceDigit() {
+	host := "0.𝟶.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.LookupIP(ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 6: Segmented digits (U+1FBF0..U+1FBF9).
+// =====================================================================
+
+// P6a: Segmented digit one (U+1FBF1).
+func p6aSegmentedDigitOne() {
+	host := "0.🯱.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.DialTimeout("tcp", net.JoinHostPort(ace, "443"), 0) // ruleid: idna-ip-literal-smuggle
+}
+
+// P6b: Segmented digit nine (U+1FBF9).
+func p6bSegmentedDigitNine() {
+	host := "0.🯹.0.0"
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = http.Post("http://"+ace, "text/plain", nil) // ruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Class 7: Trailing-dot bypass and residual propagator shapes.
+// =====================================================================
+
+// P7a: Trailing-dot bypass. Recheck is present, but no TrimRight/TrimSuffix.
+// idna.Lookup.ToASCII("0.Â¹.0.0.") returns "0.1.0.0." which net.ParseIP
+// rejects, so the recheck passes and the smuggled IP literal still
+// reaches the sink.
+func p7aTrailingDotBypass(rawHost string) {
+	ace, _ := idna.Lookup.ToASCII(rawHost)
+	if net.ParseIP(ace) != nil { // recheck without prior trim; defeated.
+		return
+	}
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80")) // todoruleid: idna-ip-literal-smuggle
+}
+
+// P7b: idna.New with multiple options -> *idna.Profile receiver shape.
+func p7bNewProfileMultiOption(rawHost string) {
+	profile := idna.New(idna.MapForLookup(), idna.Transitional(true))
+	ace, _ := profile.ToASCII(rawHost)
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80")) // todoruleid: idna-ip-literal-smuggle
+}
+
+// =====================================================================
+// Source-pattern coverage. One positive per new untrusted-input source
+// shape, validating the v0.1.0 source-set rewrite end-to-end.
+// =====================================================================
+
+// S1: *http.Request.URL.Hostname() -> ToASCII -> *http.Client.Get.
+func s1RequestURLHostname(req *http.Request, c *http.Client) {
+	host := req.URL.Hostname()
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = c.Get("http://" + ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// S2: *http.Request.Header.Get(...) -> ToASCII -> net.Dial.
+func s2RequestHeaderGet(req *http.Request) {
+	host := req.Header.Get("X-Forwarded-Host")
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "443")) // ruleid: idna-ip-literal-smuggle
+}
+
+// S3: os.Getenv(...) -> ToASCII -> http.Get.
+func s3OsGetenv() {
+	host := os.Getenv("UPSTREAM_HOST")
+	ace, _ := idna.Lookup.ToASCII(host)
+	_, _ = http.Get("http://" + ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// S4: flag.String(...) -> ToASCII -> net.LookupHost.
+func s4FlagString() {
+	hostFlag := flag.String("host", "", "upstream host")
+	flag.Parse()
+	ace, _ := idna.Lookup.ToASCII(*hostFlag)
+	_, _ = net.LookupHost(ace) // ruleid: idna-ip-literal-smuggle
+}
+
+// S5: *bufio.Scanner.Text() -> ToASCII -> net.Dial.
+func s5BufioScannerText(s *bufio.Scanner) {
+	for s.Scan() {
+		host := s.Text()
+		ace, _ := idna.Lookup.ToASCII(host)
+		_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80")) // ruleid: idna-ip-literal-smuggle
+	}
+}
+
+// S6: *json.Decoder.Decode(...) -> ToASCII -> http.Get.
+func s6JsonDecoderDecode(d *json.Decoder) {
+	var payload struct {
+		Host string `json:"host"`
+	}
+	if err := d.Decode(&payload); err != nil {
+		return
+	}
+	ace, _ := idna.Lookup.ToASCII(payload.Host)
+	_, _ = http.Get("http://" + ace) // todoruleid: idna-ip-literal-smuggle
+}
+
+// S7: *sql.Rows.Scan(...) -> ToASCII -> net.LookupIP.
+func s7SqlRowsScan(rows *sql.Rows) {
+	var host string
+	for rows.Next() {
+		if err := rows.Scan(&host); err != nil {
+			return
+		}
+		ace, _ := idna.Lookup.ToASCII(host)
+		_, _ = net.LookupIP(ace) // todoruleid: idna-ip-literal-smuggle
+	}
+}
+
+// =====================================================================
+// Negatives.
+// =====================================================================
+
+// N1: Compliant. TrimRight(".") + netip.ParseAddr recheck.
+func n1Compliant_TrimRightNetip(rawHost string) {
+	ace, _ := idna.Lookup.ToASCII(rawHost)
+	ace = strings.TrimRight(ace, ".")
+	if _, err := netip.ParseAddr(ace); err == nil {
+		return // reject: smuggled IP literal
+	}
+	// ok: idna-ip-literal-smuggle
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80"))
+}
+
+// N2: Compliant. TrimSuffix(".") + net.ParseIP recheck (legacy lenient form).
+func n2Compliant_TrimSuffixNetParseIP(rawHost string) {
+	ace, _ := idna.Lookup.ToASCII(rawHost)
+	ace = strings.TrimSuffix(ace, ".")
+	if net.ParseIP(ace) != nil {
+		return
+	}
+	// ok: idna-ip-literal-smuggle
+	_, _ = http.Get("http://" + ace)
+}
+
+// N3: Compliant. Manual slice trim + netip.ParseAddr recheck.
+// Operators sometimes hand-roll the trim. The sanitizer block accepts
+// TrimRight/TrimSuffix variants; this fixture is included as a
+// known-uncovered shape and is documented as such. Rather than alert,
+// the rule should remain quiet on the post-recheck branch when the
+// recheck logic is structurally equivalent. This case currently does
+// fire under the rule (it is a known FP) and is therefore annotated
+// as a positive expectation: see the trim-shape gap notes in the rule
+// commentary. Documented separately below as N4 / N4a so the inline
+// `ok:` line points at the genuinely-compliant trim shapes.
+//
+// (Intentionally omitted as `ok:` to avoid asserting an unsupported
+// trim shape.)
+
+// N4: Compliant. TrimRight(".") + net.ParseIP recheck.
+func n4Compliant_TrimRightNetParseIP(rawHost string) {
+	ace, _ := idna.Lookup.ToASCII(rawHost)
+	ace = strings.TrimRight(ace, ".")
+	if net.ParseIP(ace) != nil {
+		return
+	}
+	// ok: idna-ip-literal-smuggle
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80"))
+}
+
+// N5: Out of scope. idna.Punycode profile has nil mapping; no NFKC fold
+// surface, so the rule MUST NOT fire even without a recheck.
+func n5PunycodeProfile(rawHost string) {
+	ace, _ := idna.Punycode.ToASCII(rawHost)
+	// ok: idna-ip-literal-smuggle
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80"))
+}
+
+// N6: Out of scope. Devanagari digit U+0966 is status V (Valid, not
+// mapped) under UTS-46 - it is NOT in the rule's fold-class catalogue.
+// The rule's metavariable-regex source must NOT match this codepoint.
+// This fixture proves the regex does not over-fire on Valid-but-not-
+// mapped digit codepoints.
+func n6DevanagariDigit() {
+	host := "0.०.0.0" // ok: idna-ip-literal-smuggle
+	ace, _ := idna.Lookup.ToASCII(host)
+	// ok: idna-ip-literal-smuggle
+	_, _ = net.Dial("tcp", net.JoinHostPort(ace, "80"))
+}
+
+// N7: ADVERSARIAL REGRESSION TEST for the sanitizer-label-gate fix.
+//
+// adversarialUnrelatedTrimSanitizer mixes an unrelated TrimRight + ParseIP
+// construct in the same function as an IDNA-tainted path. The pre-fix
+// rule would silently sanitize the IDNA-tainted path because the
+// pattern-sanitizers block had no `requires:` constraint. With the
+// `requires: POST_IDNA` label gate the IDNA-tainted path correctly
+// triggers the alert.
+//
+// Expected: ruleid: idna-ip-literal-smuggle (alert MUST fire on JoinHostPort).
+func adversarialUnrelatedTrimSanitizer(rawHost, configValue string) string {
+	// Unrelated TrimRight + ParseIP on configValue (a separate string)
+	cleanConfig := strings.TrimRight(configValue, ".")
+	if ip := net.ParseIP(cleanConfig); ip != nil {
+		return ""
+	}
+
+	ace, err := idna.Lookup.ToASCII(rawHost)
+	if err != nil {
+		return ""
+	}
+	return net.JoinHostPort(ace, "443") // todoruleid: idna-ip-literal-smuggle
+}

--- a/go/lang/security/audit/idna-ip-literal-smuggle.yaml
+++ b/go/lang/security/audit/idna-ip-literal-smuggle.yaml
@@ -1,0 +1,369 @@
+rules:
+- id: idna-ip-literal-smuggle
+  message: >-
+    Untrusted hostname passes through golang.org/x/net/idna UTS-46
+    ToASCII mapping and then reaches a network destination with no
+    post-mapping IP-literal recheck. UTS-46 NFKC mapping folds 100
+    non-ASCII codepoints across 8 classes (Latin-1 superscripts,
+    mathematical super- and subscripts, circled digits, fullwidth
+    digits, mathematical styled digits, segmented digits) to ASCII
+    digits 0-9. An input like "0.<superscript-1>.0.0" passes a pre-IDNA
+    `net.ParseIP` check because it is not ASCII, gets mapped to
+    "0.1.0.0" by ToASCII, and reaches a network sink as if it were a
+    DNS name. The result is SSRF against link-local, RFC 1918,
+    loopback, or cloud metadata ranges.
+
+    Fix: after the IDNA call, trim trailing dots with
+    `strings.TrimRight(host, ".")` (not `TrimSuffix`, because UTS-46
+    mapping can produce multiple trailing ASCII dots when fullwidth or
+    ideographic dot characters compose with ASCII dots, and TrimSuffix
+    strips only one) and recheck with `netip.ParseAddr` (preferred, Go
+    1.18+) or `net.ParseIP`. The trim is required:
+    `idna.Lookup.ToASCII("0.<superscript-1>.0.0.")` returns "0.1.0.0.",
+    which `net.ParseIP` rejects on its own, so a recheck without the
+    trim silently passes the smuggle through. If the parse succeeds,
+    reject the input. The digit-fold layer turned it into an IP
+    literal.
+
+    Pattern: callers that apply UTS-46 IDNA mapping to a host string
+    and pass the result to a network sink without rechecking against
+    IP-literal parsers.
+
+    Tier note: this rule analyzes within a single function. Cross-file
+    taint flow is not modeled in the OSS tier; an interfile variant
+    and a CodeQL companion query live at
+    https://github.com/astrogilda/idna-ip-literal-smuggle-rules
+
+  languages: [go]
+  severity: WARNING
+  mode: taint
+  options:
+    taint_assume_safe_functions: false
+
+  pattern-sources:
+  # Label PRE_IDNA: untrusted hostname inputs.
+  - label: PRE_IDNA
+    patterns:
+    - pattern-either:
+      # HTTP request fields commonly carrying user-supplied hostnames.
+      - patterns:
+        - pattern: $REQ.Host
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $REQ.URL.Host
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $REQ.URL.Hostname()
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $URL.Host
+        - metavariable-type:
+            metavariable: $URL
+            type: "*url.URL"
+      - patterns:
+        - pattern: $URL.Hostname()
+        - metavariable-type:
+            metavariable: $URL
+            type: "*url.URL"
+      # Process inputs.
+      - pattern: os.Getenv($_)
+      - pattern: os.Args[$_]
+      - pattern: flag.String(...)
+      - pattern: flag.StringVar(...)
+      # HTTP header lookups and request plumbing.
+      - patterns:
+        - pattern: $REQ.Header.Get($_)
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $REQ.URL.Query().Get($_)
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $REQ.FormValue($_)
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      - patterns:
+        - pattern: $REQ.PostFormValue($_)
+        - metavariable-type:
+            metavariable: $REQ
+            type: "*http.Request"
+      # Stdin / scanned input.
+      - patterns:
+        - pattern: $S.Text()
+        - metavariable-type:
+            metavariable: $S
+            type: "*bufio.Scanner"
+      # Decoded JSON via *encoding/json.Decoder.
+      - patterns:
+        - pattern: $D.Decode($_)
+        - metavariable-type:
+            metavariable: $D
+            type: "*json.Decoder"
+      # Database row scans (first-arg destination).
+      - patterns:
+        - pattern: $R.Scan($DST, ...)
+        - metavariable-type:
+            metavariable: $R
+            type: "*sql.Rows"
+
+  # A hardcoded fold-class codepoint flowing into ToASCII is high
+  # confidence regardless of taint origin.
+  - label: PRE_IDNA
+    patterns:
+    - pattern: $X
+    - metavariable-regex:
+        metavariable: $X
+        # 100-codepoint UTS-46 NFKC digit-fold catalogue, derived by
+        # enumerating the Unicode 16 table shipped with x/text v0.21.0.
+        # Classes (counts):
+        #   Latin-1 superscripts U+00B2/B3/B9                              (3)
+        #   Math superscripts    U+2070, U+2074-U+2079                     (7)
+        #   Math subscripts      U+2080-U+2089                            (10)
+        #   Circled digits       U+2460-U+2468, U+24EA                    (10)
+        #   Fullwidth digits     U+FF10-U+FF19                            (10)
+        #   Math styled digits   U+1D7CE-U+1D7FF (bold/dbl/sans/mono)     (50)
+        #   Segmented digits     U+1FBF0-U+1FBF9                          (10)
+        # Excluded (status V Valid, not mapped): Arabic-Indic U+0660-0669,
+        # Extended Arabic-Indic U+06F0-06F9, Devanagari U+0966-096F.
+        regex: '"[^"]*[\x{00B2}\x{00B3}\x{00B9}\x{2070}\x{2074}-\x{2079}\x{2080}-\x{2089}\x{2460}-\x{2468}\x{24EA}\x{FF10}-\x{FF19}\x{1D7CE}-\x{1D7FF}\x{1FBF0}-\x{1FBF9}][^"]*"'
+
+  # Label transformation: when PRE_IDNA-tainted data reaches a UTS-46-mapping
+  # ToASCII call site, that call site emits a value labeled POST_IDNA. Semgrep's
+  # idiom for label transformation is a labeled source with `requires:`, not a
+  # propagator (propagators carry the same label across an expression).
+  #
+  # The package-level `idna.ToASCII` and `idna.Punycode.ToASCII` are excluded:
+  # both dispatch to the Punycode profile, which has nil mapping (no UTS-46 NFKC
+  # fold) and therefore cannot produce the digit-fold smuggle this rule targets.
+  - label: POST_IDNA
+    requires: PRE_IDNA
+    patterns:
+    - pattern-either:
+      - pattern: idna.Lookup.ToASCII(...)
+      - pattern: idna.Display.ToASCII(...)
+      - pattern: idna.Registration.ToASCII(...)
+      - pattern: idna.New(...).ToASCII(...)
+      # Var-bound profile fallback: `p := idna.Lookup; p.ToASCII(s)` and similar.
+      - patterns:
+        - pattern: $P.ToASCII(...)
+        - metavariable-type:
+            metavariable: $P
+            type: "*idna.Profile"
+
+  pattern-sinks:
+  - requires: POST_IDNA
+    patterns:
+    - pattern-either:
+      # Direct dial / resolution.
+      - pattern: net.JoinHostPort($HOST, $_)
+      - pattern: net.Dial($_, $HOST)
+      - pattern: net.DialTimeout($_, $HOST, $_)
+      - patterns:
+        - pattern: $D.Dial($_, $HOST)
+        - metavariable-type:
+            metavariable: $D
+            type: "*net.Dialer"
+      - patterns:
+        - pattern: $D.DialContext($_, $_, $HOST)
+        - metavariable-type:
+            metavariable: $D
+            type: "*net.Dialer"
+      - pattern: net.LookupHost($HOST)
+      - pattern: net.LookupIP($HOST)
+      - patterns:
+        - pattern: $R.LookupHost($_, $HOST)
+        - metavariable-type:
+            metavariable: $R
+            type: "*net.Resolver"
+      - patterns:
+        - pattern: $R.LookupIPAddr($_, $HOST)
+        - metavariable-type:
+            metavariable: $R
+            type: "*net.Resolver"
+      # http.Client convenience methods (host is embedded in the URL string).
+      - pattern: http.Get($HOST)
+      - pattern: http.Head($HOST)
+      - pattern: http.Post($HOST, $_, $_)
+      - pattern: http.PostForm($HOST, $_)
+      - patterns:
+        - pattern: $C.Get($HOST)
+        - metavariable-type:
+            metavariable: $C
+            type: "*http.Client"
+      - patterns:
+        - pattern: $C.Head($HOST)
+        - metavariable-type:
+            metavariable: $C
+            type: "*http.Client"
+      - patterns:
+        - pattern: $C.Post($HOST, $_, $_)
+        - metavariable-type:
+            metavariable: $C
+            type: "*http.Client"
+      - patterns:
+        - pattern: $C.PostForm($HOST, $_)
+        - metavariable-type:
+            metavariable: $C
+            type: "*http.Client"
+      - pattern: http.NewRequest($_, $HOST, $_)
+      - pattern: http.NewRequestWithContext($_, $_, $HOST, $_)
+      # URL / TLS / cookie field assignments.
+      - patterns:
+        - pattern: $U.Host = $HOST
+        - metavariable-type:
+            metavariable: $U
+            type: "*url.URL"
+      - pattern: |
+          url.URL{..., Host: $HOST, ...}
+      - patterns:
+        - pattern: $T.ServerName = $HOST
+        - metavariable-type:
+            metavariable: $T
+            type: "*tls.Config"
+      - pattern: |
+          tls.Config{..., ServerName: $HOST, ...}
+      - patterns:
+        - pattern: $CK.Domain = $HOST
+        - metavariable-type:
+            metavariable: $CK
+            type: "*http.Cookie"
+      - pattern: |
+          http.Cookie{..., Domain: $HOST, ...}
+      # gRPC dial.
+      - pattern: grpc.Dial($HOST, ...)
+      - pattern: grpc.DialContext($_, $HOST, ...)
+      - pattern: grpc.NewClient($HOST, ...)
+    focus-metavariable: $HOST
+
+  # Sanitizer: post-IDNA recheck only counts if a trailing-dot trim
+  # ran first. Without the trim, "0.<superscript-1>.0.0." maps to
+  # "0.1.0.0." and both net.ParseIP and netip.ParseAddr reject it, so
+  # the recheck passes and the smuggle survives.
+  #
+  # TrimRight (preferred) handles the multi-trailing-dot variants that
+  # UTS-46 mapping produces when fullwidth (U+FF0E) or ideographic
+  # (U+3002) dot characters compose with ASCII dots. TrimSuffix is
+  # accepted as a lenient barrier (it reduces FP volume on widely-used
+  # real-world callers) but is incomplete for the multi-dot variant.
+  pattern-sanitizers:
+  - by-side-effect: true
+    requires: POST_IDNA
+    patterns:
+    - pattern-either:
+      # Modern: netip.ParseAddr with prior TrimRight or TrimSuffix.
+      - pattern: |
+          $H = strings.TrimRight($H, ".")
+          ...
+          if _, $ERR := netip.ParseAddr($H); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          $H = strings.TrimRight($H, ".")
+          ...
+          if $ADDR, $ERR := netip.ParseAddr($H); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          $H = strings.TrimSuffix($H, ".")
+          ...
+          if _, $ERR := netip.ParseAddr($H); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          $H = strings.TrimSuffix($H, ".")
+          ...
+          if $ADDR, $ERR := netip.ParseAddr($H); $ERR == nil {
+            ...
+          }
+      # Legacy: net.ParseIP with prior TrimRight or TrimSuffix.
+      - pattern: |
+          $H = strings.TrimRight($H, ".")
+          ...
+          if net.ParseIP($H) != nil {
+            ...
+          }
+      - pattern: |
+          $H = strings.TrimSuffix($H, ".")
+          ...
+          if net.ParseIP($H) != nil {
+            ...
+          }
+      # Fresh-variable form. Matches the inline pattern, e.g.
+      # `if _, err := netip.ParseAddr(strings.TrimRight(out, ".")); err == nil`.
+      - pattern: |
+          $T := strings.TrimRight($H, ".")
+          ...
+          if net.ParseIP($T) != nil {
+            ...
+          }
+      - pattern: |
+          $T := strings.TrimSuffix($H, ".")
+          ...
+          if net.ParseIP($T) != nil {
+            ...
+          }
+      - pattern: |
+          $T := strings.TrimRight($H, ".")
+          ...
+          if _, $ERR := netip.ParseAddr($T); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          $T := strings.TrimSuffix($H, ".")
+          ...
+          if _, $ERR := netip.ParseAddr($T); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          if _, $ERR := netip.ParseAddr(strings.TrimRight($H, ".")); $ERR == nil {
+            ...
+          }
+      - pattern: |
+          if net.ParseIP(strings.TrimRight($H, ".")) != nil {
+            ...
+          }
+
+  # Note: `idna.StrictNoIPLiteral()` is a proposed upstream Option that
+  # has not yet landed in golang.org/x/net/idna. When it ships, add a
+  # sanitizer pattern matching
+  # `idna.New(..., idna.StrictNoIPLiteral(), ...)`
+  # to recognise callers that opt in.
+  # The Punycode profile (`idna.Punycode` / package-level `idna.ToASCII`)
+  # is out of scope for this rule: it has nil mapping and therefore cannot
+  # produce the UTS-46 digit-fold smuggle, so it is excluded from
+  # propagators rather than carved out as a sanitizer.
+
+  metadata:
+    cwe:
+    - "CWE-20: Improper Input Validation"
+    - "CWE-918: Server-Side Request Forgery (SSRF)"
+    - "CWE-176: Improper Handling of Unicode Encoding"
+    owasp:
+    - A10:2021 - Server-Side Request Forgery (SSRF)
+    - A03:2021 - Injection
+    references:
+    - https://www.unicode.org/reports/tr46/
+    - https://pkg.go.dev/golang.org/x/net/idna
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-29923
+    - https://github.com/golang/go/issues/29098
+    - https://github.com/astrogilda/idna-ip-literal-smuggle-rules
+    category: security
+    technology:
+    - go
+    - net
+    - http
+    confidence: MEDIUM
+    likelihood: MEDIUM
+    impact: HIGH
+    subcategory:
+    - vuln

--- a/go/lang/security/audit/idna-ip-literal-smuggle.yaml
+++ b/go/lang/security/audit/idna-ip-literal-smuggle.yaml
@@ -2,16 +2,19 @@ rules:
 - id: idna-ip-literal-smuggle
   message: >-
     Untrusted hostname passes through golang.org/x/net/idna UTS-46
-    ToASCII mapping and then reaches a network destination with no
-    post-mapping IP-literal recheck. UTS-46 NFKC mapping folds 100
-    non-ASCII codepoints across 8 classes (Latin-1 superscripts,
-    mathematical super- and subscripts, circled digits, fullwidth
-    digits, mathematical styled digits, segmented digits) to ASCII
-    digits 0-9. An input like "0.<superscript-1>.0.0" passes a pre-IDNA
-    `net.ParseIP` check because it is not ASCII, gets mapped to
-    "0.1.0.0" by ToASCII, and reaches a network sink as if it were a
-    DNS name. The result is SSRF against link-local, RFC 1918,
-    loopback, or cloud metadata ranges.
+    mapping (`ToASCII` or `ToUnicode` on a digit-folding profile) and
+    then reaches a network destination with no post-mapping IP-literal
+    recheck. UTS-46 NFKC mapping folds 100 non-ASCII codepoints from
+    seven Unicode-block ranges (Latin-1 superscripts, mathematical
+    superscripts, mathematical subscripts, circled digits, fullwidth
+    digits, the Mathematical Alphanumeric Symbols block, segmented
+    digits) to ASCII digits 0-9. Devanagari digits (U+0966-096F) are
+    not in scope: the library passes them through Punycode rather than
+    folding them. An input like "0.<superscript-1>.0.0" passes a
+    pre-IDNA `net.ParseIP` check because it is not ASCII, gets mapped
+    to "0.1.0.0" by the UTS-46 fold, and reaches a network sink as if
+    it were a DNS name. The result is SSRF against link-local,
+    RFC 1918, loopback, or cloud metadata ranges.
 
     Fix: after the IDNA call, trim trailing dots with
     `strings.TrimRight(host, ".")` (not `TrimSuffix`, because UTS-46
@@ -24,10 +27,6 @@ rules:
     trim silently passes the smuggle through. If the parse succeeds,
     reject the input. The digit-fold layer turned it into an IP
     literal.
-
-    Pattern: callers that apply UTS-46 IDNA mapping to a host string
-    and pass the result to a network sink without rechecking against
-    IP-literal parsers.
 
     Tier note: this rule analyzes within a single function. Cross-file
     taint flow is not modeled in the OSS tier; an interfile variant
@@ -153,9 +152,24 @@ rules:
       - pattern: idna.Display.ToASCII(...)
       - pattern: idna.Registration.ToASCII(...)
       - pattern: idna.New(...).ToASCII(...)
-      # Var-bound profile fallback: `p := idna.Lookup; p.ToASCII(s)` and similar.
+      # ToUnicode runs the same UTS-46 validateAndMap pipeline as ToASCII
+      # before the encode-vs-decode branch, so the digit fold happens
+      # regardless of which entry point is called. Empirically verified
+      # against golang.org/x/net/idna v0.53.0: Lookup.ToUnicode of a
+      # superscript-digit hostname returns the ASCII-folded form.
+      - pattern: idna.Lookup.ToUnicode(...)
+      - pattern: idna.Display.ToUnicode(...)
+      - pattern: idna.Registration.ToUnicode(...)
+      - pattern: idna.New(...).ToUnicode(...)
+      # Var-bound profile fallback covering both entry points:
+      # `p := idna.Lookup; p.ToASCII(s)` / `p.ToUnicode(s)` and similar.
       - patterns:
         - pattern: $P.ToASCII(...)
+        - metavariable-type:
+            metavariable: $P
+            type: "*idna.Profile"
+      - patterns:
+        - pattern: $P.ToUnicode(...)
         - metavariable-type:
             metavariable: $P
             type: "*idna.Profile"


### PR DESCRIPTION
# Go: idna-ip-literal-smuggle (UTS-46 NFKC digit-fold SSRF)

## Summary

- New Go security rule at `go/lang/security/audit/idna-ip-literal-smuggle.yaml` detecting an SSRF anti-pattern where an untrusted hostname is mapped through `golang.org/x/net/idna` UTS-46 mapping (`(*Profile).ToASCII` or `(*Profile).ToUnicode` on a digit-folding profile) and then reaches a network sink with no post-mapping IP-literal recheck.
- Taint mode, two labels (`PRE_IDNA`, `POST_IDNA`), label transformation at the IDNA call site, intra-procedural. Sanitizer requires a trailing-dot trim plus `netip.ParseAddr` or `net.ParseIP` recheck, in that order.
- Ships with a single Go fixture (`idna-ip-literal-smuggle.go`) carrying 23 `// ruleid:` markers covering all seven in-scope Unicode-block fold ranges plus the `ToUnicode` entry-point fold, plus 6 `// ok:` negatives covering both compliant trim variants, the Punycode out-of-scope case, and a Devanagari Valid-but-not-mapped negative control.

## Motivation

The rule complements an inter-procedural CodeQL companion query in the CodeQL community pack (PR `https://github.com/github/codeql/pull/21784`). The split is deliberate: Semgrep OSS provides a high-precision direct-call sweep that runs on free-tier CI, while CodeQL provides the inter-procedural recall vehicle for shapes where the IDNA call and the sink are wrapped behind an intermediate function (the canonical real-world `canonicalAddr`-style wrapper). The two engines hit different points on the precision/recall frontier; both are needed for a complete caller-side audit. This design is documented in `docs/research/v0.1-detection-strategy.md` of the upstream rule repository.

## Threat model

`idna.Lookup`, `idna.Display`, `idna.Registration`, and any `idna.New(idna.MapForLookup(), ...)` profile run NFKC compatibility decomposition before producing ASCII output. The fold runs in both `(*Profile).ToASCII` and `(*Profile).ToUnicode` because the library executes `validateAndMap` before the encode-vs-decode branch. Enumerating the Unicode 16 table shipped with `golang.org/x/text` v0.21.0 yields 100 codepoints partitioned into seven Unicode-block ranges that fold to ASCII digits 0-9: Latin-1 superscripts (3), mathematical superscripts (7), mathematical subscripts (10), circled digits (10), fullwidth digits (10), the Mathematical Alphanumeric Symbols block (50), segmented digits (10). Devanagari digits (U+0966..U+096F) are not in scope: empirically verified against `golang.org/x/net/idna v0.53.0`, they pass through Punycode rather than fold to ASCII. An attacker-controlled hostname containing one of these codepoints passes a pre-IDNA `net.ParseIP` check (it is not ASCII), maps to an ASCII IP literal, and reaches the sink as if it were a DNS name. The result is SSRF against loopback, RFC 1918, link-local, or cloud metadata ranges.

The trailing-dot trim is required for the post-IDNA recheck to work. `idna.Lookup.ToASCII("0.<superscript-1>.0.0.")` returns `"0.1.0.0."`, which `net.ParseIP` rejects on its own. Without the trim, the recheck silently passes and the smuggle survives. The sanitizer pattern requires both predicates, in order.

## Verification

- `semgrep --validate --config go/lang/security/audit/idna-ip-literal-smuggle.yaml` on Semgrep 1.161.0: clean.
- `semgrep --config <rule> idna-ip-literal-smuggle.go`: 23 findings, exactly matching the 23 `// ruleid:` markers.
- Sweep across `golang/go`, `kubernetes/kubernetes`, and `prometheus/prometheus` (660 MB of Go source, three projects with a high incidence of host-string handling): zero findings outside the fixture. The canonical real-world hit shape, where the IDNA call and the sink are split across a wrapper function, is intentionally out of scope for the OSS tier and is covered by the companion CodeQL query.

## Cross-language CVE precedent

- CVE-2021-29923 (Go octal IPv4 literal SSRF). Established the post-parse-recheck contract for a different normalization vector.
- CVE-2024-12224 (Servo `idna` crate): the same UTS-46 NFKC digit-fold surface, demonstrated cross-runtime.
- CVE-2024-3651 (`kjd/idna` Python): related Unicode normalization preprocessing surface in a sibling IDNA implementation.

The pattern is not Go-specific; the rule is. Each ecosystem needs its own static-analysis vehicle.

## Upstream library disposition

The Go security team reviewed an advisory for this anti-pattern and declined treating it as a library bug. The position is internally consistent: `idna.Lookup.ToASCII` is documented to implement UTS-46 mapping, and the post-mapping IP-literal recheck is a caller responsibility that the spec does not require the library to perform. Caller-side static analysis is the right vehicle for the gap, which is what this rule provides.

## Companion PR

The CodeQL community-pack PR carries the inter-procedural-recall companion query: `https://github.com/github/codeql/pull/21784`. Reviewers may find that pack useful for understanding the full coverage envelope.

## Pro and experimental variants

The OSS rule submitted here ships with intra-procedural taint only. An interfile (`interfile: true`) variant and an experimental field-name regex source-set widening (covering `Endpoint`, `Server`, `Address`, `Addr`, `Target`, `Upstream`, `Origin` field names in addition to `Host`/`Hostname`) live in the upstream rule repository at https://github.com/astrogilda/idna-ip-literal-smuggle-rules. They are not bundled into this PR because the registry convention in `go/lang/security/` is one rule per topic; operators who need cross-file recall can pull the variant directly from the upstream repository.

## Severity calibration

`WARNING`, not `ERROR`. A v0.1.x sweep across `golang/go`, `kubernetes/kubernetes`, and `prometheus/prometheus` produced zero alerts at the OSS tier, because production Go callers wrap `idna.Lookup.ToASCII` in a one-deep helper and intra-procedural taint cannot step through. The OSS tier is therefore a high-precision direct-call sweep with very low alert volume in practice; the recall vehicle is the inter-procedural CodeQL companion. Promoting to `ERROR` would not change the alert volume on real codebases but would change the failure mode on edge cases. `confidence: MEDIUM`, `likelihood: MEDIUM`, `impact: HIGH` reflect the specific attack: the precondition (caller passes user input into a UTS-46 profile) is not universal but is well-defined, and the consequence (SSRF against metadata or internal services) is severe.

## Out of scope (documented in the rule message)

- Bare `idna.ToASCII(x)` package-level helper. Punycode profile, nil mapping, no fold surface.
- WHATWG-integrated URL parsers (`url.Parse` only, no direct `idna.*.ToASCII` call). Already validated post-decode.
- IPv4-mapped IPv6 macro smuggles. Different normalization class, separate rule.

## CLA

Will sign on first PR comment via cla-assistant.

---

Canonical source for these artefacts: https://github.com/astrogilda/idna-ip-literal-smuggle-rules

