### PR TITLE
Add detect-ollama AI usage rule

### DIFF
--- a/ai/python/detect-ollama.py
+++ b/ai/python/detect-ollama.py
@@ -1,0 +1,21 @@
+# ruleid: detect-ollama
+import ollama
+
+# ruleid: detect-ollama
+response = ollama.chat(
+    model="llama3.1",
+    messages=[{"role": "user", "content": "Why is the sky blue?"}],
+)
+
+# ruleid: detect-ollama
+stream = ollama.generate(model="llama3.1", prompt="Count to ten.")
+
+# ruleid: detect-ollama
+from ollama import Client
+
+client = Client(host="http://localhost:11434")
+# ruleid: detect-ollama
+chat_response = client.chat(
+    model="llama3.1",
+    messages=[{"role": "user", "content": "Hello"}],
+)

--- a/ai/python/detect-ollama.py
+++ b/ai/python/detect-ollama.py
@@ -13,9 +13,20 @@ stream = ollama.generate(model="llama3.1", prompt="Count to ten.")
 # ruleid: detect-ollama
 from ollama import Client
 
-client = Client(host="http://localhost:11434")
 # ruleid: detect-ollama
+client = Client(host="http://localhost:11434")
 chat_response = client.chat(
     model="llama3.1",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+foo = SomeUnrelatedClient()
+# ok: detect-ollama
+foo.chat("hi")
+
+openai_client = OpenAI(api_key="sk-...")
+# ok: detect-ollama
+completion = openai_client.chat(
+    model="gpt-4o",
     messages=[{"role": "user", "content": "Hello"}],
 )

--- a/ai/python/detect-ollama.yaml
+++ b/ai/python/detect-ollama.yaml
@@ -6,7 +6,7 @@ rules:
     message: "Possibly found usage of AI: Ollama"
     pattern-either:
       - pattern: import ollama
-      - pattern: from ollama import $ANYTHING
+      - pattern: from ollama import $_
       - pattern: ollama.chat(...)
       - pattern: ollama.generate(...)
       - pattern: |

--- a/ai/python/detect-ollama.yaml
+++ b/ai/python/detect-ollama.yaml
@@ -9,7 +9,18 @@ rules:
       - pattern: from ollama import $ANYTHING
       - pattern: ollama.chat(...)
       - pattern: ollama.generate(...)
-      - pattern: $CLIENT.chat(...,model=...,...)
+      - pattern: |
+          $CLIENT = ollama.Client(...)
+          ...
+          $CLIENT.chat(...,model=...,...)
+      - patterns:
+          - pattern: |
+              $CLIENT = Client(...)
+              ...
+              $CLIENT.chat(...,model=...,...)
+          - pattern-inside: |
+              from ollama import Client
+              ...
     metadata:
       references:
         - https://semgrep.dev/blog/2024/detecting-shadow-ai

--- a/ai/python/detect-ollama.yaml
+++ b/ai/python/detect-ollama.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: detect-ollama
+    languages:
+      - python
+    severity: INFO
+    message: "Possibly found usage of AI: Ollama"
+    pattern-either:
+      - pattern: import ollama
+      - pattern: from ollama import $ANYTHING
+      - pattern: ollama.chat(...)
+      - pattern: ollama.generate(...)
+      - pattern: $CLIENT.chat(...,model=...,...)
+    metadata:
+      references:
+        - https://semgrep.dev/blog/2024/detecting-shadow-ai
+      category: maintainability
+      technology:
+        - genAI
+        - LLMs
+      confidence: LOW


### PR DESCRIPTION
## Summary

Adds a `detect-ollama` rule under `ai/python/`, extending the existing
"shadow AI" detection rules (e.g. `detect-openai`, `detect-anthropic`,
`detect-mistral`) to cover the Ollama Python SDK.

## Details

Ollama is a widely used local-LLM runtime. The rule matches:
- `import ollama` / `from ollama import ...`
- module-level `ollama.chat(...)` and `ollama.generate(...)` calls
- client usage `Client().chat(model=...)` (anchored on `model=`, matching the
  convention used by `detect-mistral`)

Severity/category/confidence and the reference link match the other
`ai/python` rules.

## Testing

`semgrep --test --config ai/python/detect-ollama.yaml ai/python/detect-ollama.py`
passes (all annotated lines match, nothing else does).