### PR TITLE
Add detect-groq AI usage rule

### DIFF
--- a/ai/python/detect-groq.py
+++ b/ai/python/detect-groq.py
@@ -1,4 +1,7 @@
 # ruleid: detect-groq
+import groq
+
+# ruleid: detect-groq
 from groq import Groq
 
 # ruleid: detect-groq
@@ -15,3 +18,6 @@ from groq import AsyncGroq
 
 # ruleid: detect-groq
 async_client = AsyncGroq()
+
+# ok: detect-groq
+import unrelated_sdk

--- a/ai/python/detect-groq.py
+++ b/ai/python/detect-groq.py
@@ -1,0 +1,17 @@
+# ruleid: detect-groq
+from groq import Groq
+
+# ruleid: detect-groq
+client = Groq(
+    api_key="MY_API_KEY",
+)
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Explain the importance of fast LLMs"}],
+    model="llama-3.3-70b-versatile",
+)
+
+# ruleid: detect-groq
+from groq import AsyncGroq
+
+# ruleid: detect-groq
+async_client = AsyncGroq()

--- a/ai/python/detect-groq.yaml
+++ b/ai/python/detect-groq.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: detect-groq
+    languages:
+      - python
+    severity: INFO
+    message: "Possibly found usage of AI: Groq"
+    pattern-either:
+      - pattern: import groq
+      - pattern: from groq import $ANYTHING
+      - pattern: Groq(...)
+      - pattern: AsyncGroq(...)
+    metadata:
+      references:
+        - https://semgrep.dev/blog/2024/detecting-shadow-ai
+      category: maintainability
+      technology:
+        - genAI
+        - LLMs
+      confidence: LOW

--- a/ai/python/detect-groq.yaml
+++ b/ai/python/detect-groq.yaml
@@ -6,7 +6,7 @@ rules:
     message: "Possibly found usage of AI: Groq"
     pattern-either:
       - pattern: import groq
-      - pattern: from groq import $ANYTHING
+      - pattern: from groq import $_
       - pattern: Groq(...)
       - pattern: AsyncGroq(...)
     metadata:


### PR DESCRIPTION
## Summary

Adds a `detect-groq` rule under `ai/python/`, extending the existing
"shadow AI" detection rules to cover the Groq Python SDK.

## Details

Groq is a widely used low-latency inference provider. The rule matches:
- `import groq` / `from groq import ...`
- the `Groq(...)` and `AsyncGroq(...)` client constructors

These anchors are specific to the Groq SDK. (The chat call itself,
`client.chat.completions.create(...)`, mirrors the OpenAI surface and is
intentionally left to `detect-openai`'s generic pattern to avoid duplication.)
Severity/category/confidence and the reference link match the other
`ai/python` rules.

## Testing

`semgrep --test --config ai/python/detect-groq.yaml ai/python/detect-groq.py`
passes (all annotated lines match, nothing else does).