### PR TITLE
Add uv-script-unpinned-dependency rule (follow-up to #3791 / #3805)

### DIFF
--- a/package_managers/uv/uv-script-unpinned-dependency.test.py
+++ b/package_managers/uv/uv-script-unpinned-dependency.test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Test cases for uv-script-unpinned-dependency."""
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+# ruleid: uv-script-unpinned-dependency
+#   "httpx",
+# ruleid: uv-script-unpinned-dependency
+#   "requests>=2.0",
+# ruleid: uv-script-unpinned-dependency
+#   "flask~=2.0",
+# ruleid: uv-script-unpinned-dependency
+#   "rich",
+# ruleid: uv-script-unpinned-dependency
+#   "django>=4.0,<5.0",
+# ruleid: uv-script-unpinned-dependency
+#   "requests[security]",
+# ruleid: uv-script-unpinned-dependency
+#   "httpx!=0.27.0",
+# ok: uv-script-unpinned-dependency
+#   "numpy==1.24.0",
+# ok: uv-script-unpinned-dependency
+#   "pandas==2.1.0",
+# ok: uv-script-unpinned-dependency
+#   "requests[security]==2.31.0",
+# ok: uv-script-unpinned-dependency
+#   "flask @ git+https://github.com/pallets/flask.git",
+# ok: uv-script-unpinned-dependency
+#   "django @ git+ssh://[email protected]/django/django.git",
+# ]
+#
+# [tool.ruff]
+# A tool table inside script metadata must not be flagged because the
+# dependency array is the only place dependency specifiers live.
+# ok: uv-script-unpinned-dependency
+# line-length = "100"
+# ///
+
+import httpx
+
+# A bare quoted name outside the script metadata block must not be flagged.
+# ok: uv-script-unpinned-dependency
+"httpx"
+
+# ok: uv-script-unpinned-dependency
+x = "requests"
+
+print(httpx.get("http://example.com"))

--- a/package_managers/uv/uv-script-unpinned-dependency.yaml
+++ b/package_managers/uv/uv-script-unpinned-dependency.yaml
@@ -1,0 +1,61 @@
+---
+rules:
+  - id: uv-script-unpinned-dependency
+    patterns:
+      - pattern-inside: |
+          # /// script
+          ...
+          # ///
+      - pattern-inside: |
+          # dependencies = [
+          ...
+          # ]
+      - pattern-regex: '"[a-zA-Z][\w.-]*[^"]*"'
+      - pattern-not-regex: '==\s*[0-9]'
+      - pattern-not-regex: '://'
+      - pattern-not-regex: '@\s'
+    message: |
+      This uv inline script dependency is not pinned to an exact version with
+      `==`. Unpinned dependencies can resolve to different versions over time,
+      including newly published malicious versions. Pin each dependency to a
+      specific version using `==`.
+
+      Example:
+
+      ```python
+      # /// script
+      # dependencies = [
+      #   "httpx==0.27.0",
+      # ]
+      # ///
+      ```
+
+      Reference: https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/*.py"
+        - "**/*.pyw"
+    options:
+      generic_ellipsis_max_span: 50
+    metadata:
+      category: security
+      technology:
+        - uv
+        - python
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies
+        - https://packaging.python.org/en/latest/specifications/inline-script-metadata/


### PR DESCRIPTION
Per @0xDC0DE's request in https://github.com/semgrep/semgrep-rules/pull/3791#issuecomment-4212859305, this is a small follow-up extracting the one rule from #3791 that #3805 did not cover.

## What this adds

`uv-script-unpinned-dependency` flags unpinned dependencies inside PEP 723 inline script metadata blocks in Python files:

```python
#!/usr/bin/env python3
# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "httpx",            # flagged: no version pin
#   "requests>=2.0",    # flagged: lower bound only
#   "click==8.1.7",     # OK: exact pin
# ]
# ///
```

uv resolves these dependencies at script execution time, so any non-exact specifier can pull a newly published, potentially malicious version. The rule is scoped to the `dependencies = [...]` array inside `# /// script` ... `# ///` blocks and excludes direct references (URL refs, PEP 508 `@` refs) which have their own integrity story.

## Notes

- Uses `message: |` per https://github.com/semgrep/semgrep-rules/pull/3791#discussion_r3026436948.
- Severity, metadata, and directory layout follow the conventions established by #3805 (`package_managers/uv/`, `severity: MEDIUM`, `.test.py` test file).
- `ok` cases for exact pins, pins with extras, and direct refs (https, git+ssh) are included.

## The other rule from #3791

`npmrc-missing-min-release-age` is intentionally dropped from this follow-up. #3805 already shipped `npm-missing-minimum-release-age` that targets the same file (`.npmrc`) and additionally validates the configured threshold (e.g., catches `min-release-age=0`), which my original `pattern-not-regex` version did not. Re-introducing a weaker overlapping rule would just add noise.

## Tests

```
$ semgrep --test --config package_managers/uv/uv-script-unpinned-dependency.yaml package_managers/uv/uv-script-unpinned-dependency.test.py
1/1: All tests passed
```

Closes #3791.

cc @0xDC0DE