### PR TITLE
Add llm-output-to-sql taint rule for Python

### DIFF
--- a/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.py
+++ b/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.py
@@ -1,0 +1,54 @@
+from openai import OpenAI
+from langchain_openai import ChatOpenAI
+import sqlalchemy
+
+client = OpenAI()
+llm = ChatOpenAI()
+
+
+def vulnerable_fstring(cursor):
+    r = client.chat.completions.create(
+        model="gpt-4", messages=[{"role": "user", "content": "table name"}]
+    )
+    table = r.choices[0].message.content
+    # ruleid: llm-output-to-sql-python
+    cursor.execute(f"SELECT * FROM {table}")
+
+
+def vulnerable_sqlalchemy(conn):
+    r = client.chat.completions.create(
+        model="gpt-4", messages=[{"role": "user", "content": "filter"}]
+    )
+    filt = r.choices[0].message.content
+    # ruleid: llm-output-to-sql-python
+    conn.execute(sqlalchemy.text("SELECT * FROM orders WHERE status = '" + filt + "'"))
+
+
+def vulnerable_langchain_invoke(cursor):
+    resp = llm.invoke("give me a column name")
+    col = resp.content
+    # ruleid: llm-output-to-sql-python
+    cursor.execute(f"SELECT {col} FROM users")
+
+
+def vulnerable_django_raw(User):
+    r = client.chat.completions.create(
+        model="gpt-4", messages=[{"role": "user", "content": "where clause"}]
+    )
+    clause = r.choices[0].message.content
+    # ruleid: llm-output-to-sql-python
+    User.objects.raw("SELECT * FROM users WHERE " + clause)
+
+
+def safe_parameterized(cursor):
+    r = client.chat.completions.create(
+        model="gpt-4", messages=[{"role": "user", "content": "status"}]
+    )
+    status = r.choices[0].message.content
+    # ok: llm-output-to-sql-python
+    cursor.execute("SELECT * FROM orders WHERE status = %s", (status,))
+
+
+def safe_hardcoded(cursor):
+    # ok: llm-output-to-sql-python
+    cursor.execute("SELECT * FROM users WHERE id = 1")

--- a/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.yaml
+++ b/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.yaml
@@ -17,6 +17,10 @@ rules:
       likelihood: MEDIUM
       impact: HIGH
       technology: [openai, anthropic, gemini, langchain]
+      owasp:
+        - "A03:2021 - Injection"
+      vulnerability_class:
+        - "SQL Injection"
       references:
         - https://genai.owasp.org/llmrisk/llm01-prompt-injection/
     pattern-sources:

--- a/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.yaml
+++ b/ai/ai-best-practices/llm-output-to-sql/llm-output-to-sql-python.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: llm-output-to-sql-python
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: >-
+      LLM API response data flows into a raw SQL query. A compromised or
+      manipulated LLM response (e.g. via prompt injection or RAG context
+      poisoning) can inject SQL and read, modify, or destroy data. Never build
+      SQL by interpolating LLM output; use parameterized queries / bound
+      parameters and validate the model output first.
+    metadata:
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      category: security
+      confidence: HIGH
+      subcategory: [vuln]
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [openai, anthropic, gemini, langchain]
+      references:
+        - https://genai.owasp.org/llmrisk/llm01-prompt-injection/
+    pattern-sources:
+      - pattern: $CLIENT.chat.completions.create(...)
+      - pattern: $CLIENT.messages.create(...)
+      - pattern: $MODEL.generate_content(...)
+      - pattern: $CLIENT.chat(...)
+      - pattern: $LLM.invoke(...)
+    pattern-sinks:
+      - patterns:
+          - pattern: $CURSOR.execute($SINK, ...)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: $CURSOR.executemany($SINK, ...)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: sqlalchemy.text($SINK)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: $MODEL.objects.raw($SINK, ...)
+          - focus-metavariable: $SINK


### PR DESCRIPTION
## What this adds
A new taint-mode rule, `llm-output-to-sql-python`, that flags LLM API
response data flowing into raw SQL execution (CWE-89). It's the SQL
sibling of the existing `ai/ai-best-practices/llm-output-to-exec` rule.

## Why
Text-to-SQL and agentic LLM features increasingly let model output reach
database queries directly. Combined with prompt injection or RAG context
poisoning (OWASP LLM01), a manipulated response can inject SQL. There's a
rule for LLM-output-to-exec, but no SQL equivalent yet.

## How it works
- Mode: taint
- Sources: OpenAI / Anthropic / Gemini chat & completion calls, plus
  LangChain `.invoke(...)`
- Sinks: `cursor.execute` / `executemany`, `sqlalchemy.text(...)`,
  Django `.objects.raw(...)`
- Parameterized queries are not flagged: the focus metavariable is the
  query string, so passing tainted data as a bound parameter stays clean.

## Tests
`semgrep --test` passes — 4 true-positive cases fire, 2 safe cases
(parameterized + hardcoded) stay clean.

## Open questions for maintainers
1. Placement: I put it next to `llm-output-to-exec` under
   `ai/ai-best-practices/`. Happy to move it if that isn't the right
   home for community-contributed rules.
2. The `.invoke(...)` source is intentionally broad and could over-fire
   outside LLM contexts, glad to tighten it to specific client classes
   if you'd prefer.

Open to feedback.