### PR TITLE
fix(flask): make-response-with-unknown-content: exclude explicit content-type/mimetype

### DIFF
--- a/python/flask/security/audit/xss/make-response-with-unknown-content.py
+++ b/python/flask/security/audit/xss/make-response-with-unknown-content.py
@@ -58,6 +58,22 @@ make_response(t)
 
 unk = fxn()
 
+# ok: make-response-with-unknown-content
+resp2 = flask.make_response(unk)
+resp2.content_type = "application/json"
+
+# ok: make-response-with-unknown-content
+resp3 = flask.make_response(unk)
+resp3.mimetype = "application/json"
+
+# ok: make-response-with-unknown-content
+resp4 = flask.make_response(unk)
+resp4.headers["Content-Type"] = "application/json"
+
+# ok: make-response-with-unknown-content
+resp5 = flask.make_response(unk)
+resp5.mimetype = MIME_TYPE['json']
+
 # ruleid: make-response-with-unknown-content
 make_response(unk)
 

--- a/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
+++ b/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
@@ -21,6 +21,30 @@ rules:
           $X = json.dumps(...)
           ...
           flask.make_response($X, ...)
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.content_type = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.mimetype = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.content_type = $CTYPE
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.mimetype = $MIME
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.headers["Content-Type"] = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.headers["content-type"] = "..."
     message: >-
       Be careful with `flask.make_response()`. If this response is rendered onto a webpage,
       this could create a cross-site scripting (XSS) vulnerability. `flask.make_response()`


### PR DESCRIPTION
## Summary

- Adds `pattern-not-inside` clauses to `make-response-with-unknown-content` to exclude cases where the Flask response object's `content_type`, `mimetype`, or `Content-Type` header is explicitly set after construction
- When a developer explicitly sets the response content type, the browser uses the declared type rather than sniffing HTML, which mitigates the XSS risk the rule is designed to catch
- Adds four new `ok:` test cases exercising each suppression shape (`content_type = "..."`, `mimetype = "..."`, `headers["Content-Type"] = "..."`, `mimetype = variable`)

## Scope note

The existing `switch()` function pattern in the test file (make_response inside an if/else branch, mimetype set after the branch) remains as `ruleid:` — Semgrep's `pattern-not-inside` does not track a metavar assigned inside a branch and used outside it, so that shape cannot be suppressed with this approach. The new patterns cover the common linear assignment shape.

## Test plan

- [x] `semgrep --test` passes: all existing `ruleid:` cases still fire, all new `ok:` cases are suppressed
- [x] No regression on existing `ruleid:` test cases