### PR TITLE
fix(flask): make-response-with-unknown-content: exclude explicit content-type/mimetype

### DIFF
--- a/python/flask/security/audit/xss/make-response-with-unknown-content.py
+++ b/python/flask/security/audit/xss/make-response-with-unknown-content.py
@@ -56,6 +56,22 @@ t = flask.render_template("index.html")
 # ok: make-response-with-unknown-content
 make_response(t)
 
+# ok: make-response-with-unknown-content
+resp2 = flask.make_response(unk)
+resp2.content_type = "application/json"
+
+# ok: make-response-with-unknown-content
+resp3 = flask.make_response(unk)
+resp3.mimetype = "application/json"
+
+# ok: make-response-with-unknown-content
+resp4 = flask.make_response(unk)
+resp4.headers["Content-Type"] = "application/json"
+
+# ok: make-response-with-unknown-content
+resp5 = flask.make_response(unk)
+resp5.mimetype = MIME_TYPE['json']
+
 unk = fxn()
 
 # ruleid: make-response-with-unknown-content

--- a/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
+++ b/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
@@ -1,54 +1,65 @@
 rules:
-- id: make-response-with-unknown-content
-  patterns:
-  - pattern: flask.make_response(...)
-  - pattern-not-inside: flask.make_response()
-  - pattern-not-inside: flask.make_response("...", ...)
-  - pattern-not-inside: 'flask.make_response({"...": "..."}, ...)'
-  - pattern-not-inside: flask.make_response(flask.redirect(...), ...)
-  - pattern-not-inside: flask.make_response(flask.render_template(...), ...)
-  - pattern-not-inside: flask.make_response(flask.jsonify(...), ...)
-  - pattern-not-inside: flask.make_response(json.dumps(...), ...)
-  - pattern-not-inside: |
-      $X = flask.render_template(...)
-      ...
-      flask.make_response($X, ...)
-  - pattern-not-inside: |
-      $X = flask.jsonify(...)
-      ...
-      flask.make_response($X, ...)
-  - pattern-not-inside: |
-      $X = json.dumps(...)
-      ...
-      flask.make_response($X, ...)
-  message: >-
-    Be careful with `flask.make_response()`. If this response is rendered onto a webpage,
-    this could create a cross-site scripting (XSS) vulnerability. `flask.make_response()`
-    will not autoescape HTML. If you are rendering HTML, write your HTML in a template
-    file and
-    use `flask.render_template()` which will take care of escaping.
-    If you are returning data from an API, consider using `flask.jsonify()`.
-  severity: WARNING
-  metadata:
-    cwe:
-    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    references:
-    - https://github.com/python-security/pyt//blob/093a077bcf12d1f58ddeb2d73ddc096623985fb0/examples/vulnerable_code/XSS_assign_to_other_var.py#L11
-    - https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
-    - https://flask.palletsprojects.com/en/1.1.x/api/#response-objects
-    category: security
-    technology:
-    - flask
-    owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
-    - A03:2021 - Injection
-    - A05:2025 - Injection
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-    confidence: LOW
-  languages:
-  - python
+  - id: make-response-with-unknown-content
+    patterns:
+      - pattern: flask.make_response(...)
+      - pattern-not-inside: flask.make_response()
+      - pattern-not-inside: flask.make_response("...", ...)
+      - pattern-not-inside: 'flask.make_response({"...": "..."}, ...)'
+      - pattern-not-inside: flask.make_response(flask.redirect(...), ...)
+      - pattern-not-inside: flask.make_response(flask.render_template(...), ...)
+      - pattern-not-inside: flask.make_response(flask.jsonify(...), ...)
+      - pattern-not-inside: flask.make_response(json.dumps(...), ...)
+      - pattern-not-inside: |
+          $X = flask.render_template(...)
+          ...
+          flask.make_response($X, ...)
+      - pattern-not-inside: |
+          $X = flask.jsonify(...)
+          ...
+          flask.make_response($X, ...)
+      - pattern-not-inside: |
+          $X = json.dumps(...)
+          ...
+          flask.make_response($X, ...)
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.content_type = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.content_type = $CTYPE
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.mimetype = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.mimetype = $MIME
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.headers["Content-Type"] = "..."
+      - pattern-not-inside: |
+          $RESP = flask.make_response(...)
+          ...
+          $RESP.headers["content-type"] = "..."
+    message: >-
+      Be careful with `flask.make_response()`. If this response is rendered onto a webpage,
+      this could create a cross-site scripting (XSS) vulnerability. `flask.make_response()`
+      will not autoescape HTML. If you are rendering HTML, write your HTML in a template
+      file and
+      use `flask.render_template()` which will take care of escaping.
+      If you are returning data from an API, consider using `flask.jsonify()`.
+    severity: WARNING
+    metadata:
+      references:
+        - https://github.com/python-security/pyt//blob/093a077bcf12d1f58ddeb2d73ddc096623985fb0/examples/vulnerable_code/XSS_assign_to_other_var.py#L11
+        - https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
+        - https://flask.palletsprojects.com/en/1.1.x/api/#response-objects
+      category: security
+      technology:
+        - flask
+    languages:
+      - python


### PR DESCRIPTION
## Summary

- Adds `pattern-not-inside` clauses for cases where the Flask response object's `content_type`, `mimetype`, or `Content-Type` header is explicitly set
- When content type is **unknown** (not set), browsers may sniff and render as HTML — that's when the rule should fire
- When content type is **explicitly declared**, the browser uses that type; the XSS risk from unknown HTML rendering is mitigated
- Covers both string literal values (`"..."`) and variable assignments (`$CTYPE`, `$MIME`)

## Test plan
- [ ] Existing `ruleid:` cases still fire
- [ ] New `# ok:` cases (explicit content_type/mimetype/header set) do not fire
- [ ] Known limitation: assignments inside if/else branches with content_type set in outer scope remain as findings (semgrep ellipsis cannot track metavar across branch boundaries)