### PR TITLE
Even more package manager security rules

### DIFF
--- a/package_managers/npm/npm-missing-minimum-release-age.yaml
+++ b/package_managers/npm/npm-missing-minimum-release-age.yaml
@@ -32,7 +32,6 @@ rules:
       `min-release-age = 7` to wait 7 days before resolving newly
       published package versions.
       Added in: v11.10
-      Reference: https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/
     languages:
       - generic
     severity: MEDIUM

--- a/package_managers/npm/npmrc-allow-git-unrestricted.test.npmrc
+++ b/package_managers/npm/npmrc-allow-git-unrestricted.test.npmrc
@@ -1,0 +1,123 @@
+---
+# ruleid: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+save-exact=true
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+@myorg:registry=https://npm.pkg.github.com
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+# allow-git=none
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+ignore-scripts=true
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=all
+
+---
+registry=https://registry.npmjs.org
+ignore-scripts=true
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=all
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=root
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=true
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=false
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=0
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=1
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=yes
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=no
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=on
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=off
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=null
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=False
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=TRUE
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=None
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=ALL
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=ROOT
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=NONE
+
+---
+# ruleid: npmrc-allow-git-unrestricted
+allow-git=
+
+---
+# ok: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+allow-git=none
+
+---
+# ok: npmrc-allow-git-unrestricted
+allow-git=none
+registry=https://registry.npmjs.org
+
+---
+# ok: npmrc-allow-git-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+allow-git=none
+
+---
+# ok: npmrc-allow-git-unrestricted
+allow-git=none

--- a/package_managers/npm/npmrc-allow-git-unrestricted.yaml
+++ b/package_managers/npm/npmrc-allow-git-unrestricted.yaml
@@ -1,0 +1,61 @@
+---
+rules:
+  - id: npmrc-allow-git-unrestricted
+    message: >-
+      This `.npmrc` does not restrict git-sourced dependencies. The `allow-git`
+      setting controls which git-URL dependencies npm will resolve: `all`
+      (default) allows any git dependency; `root` allows only git dependencies
+      defined in your project's own `package.json`; `none` blocks all git
+      dependencies. A malicious git dependency can bundle its own `.npmrc` that
+      overrides the git executable itself, achieving arbitrary code execution
+      even when `ignore-scripts=true` is set — this is the one attack vector
+      that `ignore-scripts` alone cannot close. `root` is insufficient: it still
+      permits git-sourced packages in the root project. Set `allow-git=none` to
+      prevent npm from resolving any git-sourced dependency. Available since npm
+      11.10.0.
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/.npmrc"
+      exclude:
+        - "**/node_modules/**"
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/fixtures/**"
+        - "**/__fixtures__/**"
+    pattern-either:
+      # Branch 1: allow-git key is absent entirely.
+      # Matches the whole document as $TARGET so pattern-not-regex checks the
+      # full document scope regardless of key ordering.
+      - patterns:
+          - pattern-regex: '(?:(?:^---\n)(?:[^\n]*\n)|^)(?P<TARGET>(?:(?!\n---)[\s\S])*\S(?:(?!\n---)[\s\S])*)'
+          - pattern-not-regex: '(?m)^allow-git\s*='
+          - focus-metavariable: $TARGET
+      # Branch 2: allow-git set to any value other than the exact canonical
+      # "none". "all", "root", boolean aliases ("true", "false", "yes", "no"),
+      # numeric aliases, and mixed-case variants are all flagged — only
+      # lowercase "none" is safe.
+      - pattern-regex: '(?m)^allow-git\s*=\s*(?!none\b)\S[^\n]*'
+      # Branch 3: allow-git set to empty value (bare equals sign).
+      # Branch 2 requires \S so it cannot match an empty RHS.
+      - pattern-regex: '(?m)^allow-git\s*=\s*$'
+    metadata:
+      category: security
+      technology:
+        - npm
+        - nodejs
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.npmjs.com/cli/v11/using-npm/config#allow-git

--- a/package_managers/npm/npmrc-allow-remote-unrestricted.test.npmrc
+++ b/package_managers/npm/npmrc-allow-remote-unrestricted.test.npmrc
@@ -1,0 +1,124 @@
+---
+# ruleid: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+save-exact=true
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+allow-git=none
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+# allow-remote=none
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+ignore-scripts=true
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=all
+
+---
+registry=https://registry.npmjs.org
+ignore-scripts=true
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=all
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=root
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=true
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=false
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=0
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=1
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=yes
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=no
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=on
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=off
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=null
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=False
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=TRUE
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=None
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=ALL
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=ROOT
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=NONE
+
+---
+# ruleid: npmrc-allow-remote-unrestricted
+allow-remote=
+
+---
+# ok: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+allow-remote=none
+
+---
+# ok: npmrc-allow-remote-unrestricted
+allow-remote=none
+registry=https://registry.npmjs.org
+
+---
+# ok: npmrc-allow-remote-unrestricted
+registry=https://registry.npmjs.org
+ignore-scripts=true
+allow-git=none
+allow-remote=none
+
+---
+# ok: npmrc-allow-remote-unrestricted
+allow-remote=none

--- a/package_managers/npm/npmrc-allow-remote-unrestricted.yaml
+++ b/package_managers/npm/npmrc-allow-remote-unrestricted.yaml
@@ -1,0 +1,61 @@
+---
+rules:
+  - id: npmrc-allow-remote-unrestricted
+    message: >-
+      This `.npmrc` does not restrict remote URL dependencies. The
+      `allow-remote` setting controls which URL-based tarball dependencies npm
+      will resolve: `all` (default) allows any https URL; `root` allows only
+      URL dependencies defined in your project's own `package.json`; `none`
+      blocks all URL dependencies. Remote URL dependencies bypass the npm
+      registry entirely, making it impossible to audit packages through standard
+      registry tooling such as provenance attestations or audit advisories.
+      `root` is insufficient: it still permits URL-sourced packages in the root
+      project. Distinct from git deps: both should be restricted independently.
+      Set `allow-remote=none` to prevent npm from fetching any remote tarball
+      dependency. Available since npm 11.15.0.
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/.npmrc"
+      exclude:
+        - "**/node_modules/**"
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/fixtures/**"
+        - "**/__fixtures__/**"
+    pattern-either:
+      # Branch 1: allow-remote key is absent entirely.
+      # Matches the whole document as $TARGET so pattern-not-regex checks the
+      # full document scope regardless of key ordering.
+      - patterns:
+          - pattern-regex: '(?:(?:^---\n)(?:[^\n]*\n)|^)(?P<TARGET>(?:(?!\n---)[\s\S])*\S(?:(?!\n---)[\s\S])*)'
+          - pattern-not-regex: '(?m)^allow-remote\s*='
+          - focus-metavariable: $TARGET
+      # Branch 2: allow-remote set to any value other than the exact canonical
+      # "none". "all", "root", boolean aliases ("true", "false", "yes", "no"),
+      # numeric aliases, and mixed-case variants are all flagged — only
+      # lowercase "none" is safe.
+      - pattern-regex: '(?m)^allow-remote\s*=\s*(?!none\b)\S[^\n]*'
+      # Branch 3: allow-remote set to empty value (bare equals sign).
+      # Branch 2 requires \S so it cannot match an empty RHS.
+      - pattern-regex: '(?m)^allow-remote\s*=\s*$'
+    metadata:
+      category: security
+      technology:
+        - npm
+        - nodejs
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote

--- a/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
+++ b/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
@@ -5,7 +5,6 @@ rules:
       Missing or incorrect blockExoticSubdeps. Set `blockExoticSubdeps: true`
       to transitive dependencies from being installed from untrusted sources.
       Added in: v10.26.0
-      Reference: https://pnpm.io/settings#blockexoticsubdeps
     languages:
       - yaml
     severity: MEDIUM
@@ -15,7 +14,7 @@ rules:
     pattern-either:
       # Branch 1: Missing entirely
       - patterns:
-          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog|catalogs)\s*:)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
           - focus-metavariable: $TARGET
 
       # Branch 2: Wrong value (not no-downgrade)

--- a/package_managers/pnpm/pnpm-dangerously-allow-all-builds.test.yaml
+++ b/package_managers/pnpm/pnpm-dangerously-allow-all-builds.test.yaml
@@ -1,0 +1,147 @@
+---
+# ok: pnpm-dangerously-allow-all-builds
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-dangerously-allow-all-builds
+catalog:
+  react: ^19.0.0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: true
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: yes
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: 1
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: on
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds:
+
+---
+# ok: pnpm-dangerously-allow-all-builds
+packages:
+  - "apps/*"
+dangerouslyAllowAllBuilds: false
+
+---
+# ok: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: false
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-dangerously-allow-all-builds
+catalogs:
+  default:
+    react: ^19.0.0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: True
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: TRUE
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: YES
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: ON
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: no
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: off
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: 0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: 'true'
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: 'false'
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: ~
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: null
+
+---
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: true
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-dangerously-allow-all-builds
+packages:
+  - "apps/*"
+# dangerouslyAllowAllBuilds: false
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: "true"
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-dangerously-allow-all-builds
+dangerouslyAllowAllBuilds: "false"

--- a/package_managers/pnpm/pnpm-dangerously-allow-all-builds.yaml
+++ b/package_managers/pnpm/pnpm-dangerously-allow-all-builds.yaml
@@ -1,0 +1,51 @@
+---
+rules:
+  - id: pnpm-dangerously-allow-all-builds
+    message: >-
+      This pnpm workspace has `dangerouslyAllowAllBuilds` enabled. When set to
+      `true`, all build scripts (preinstall, install, postinstall) from
+      dependencies run automatically during installation without requiring
+      per-package approval via the `allowBuilds` allowlist. This completely
+      disables pnpm's build script approval mechanism, making every
+      dependency capable of executing arbitrary code at install time (the
+      primary vector for supply-chain attacks). Set
+      `dangerouslyAllowAllBuilds: false` and use `allowBuilds` to explicitly
+      approve trusted packages that require build scripts.
+      Added in: v10.9.0
+    languages:
+      - yaml
+    severity: HIGH
+    paths:
+      include:
+        - "**/pnpm-workspace.yaml"
+    pattern-either:
+      # Branch 1: Key present with any value other than canonical false
+      - patterns:
+          - pattern: |
+              dangerouslyAllowAllBuilds: $VAL
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?!false$).+'
+          - focus-metavariable: $VAL
+
+      # Branch 3: Key present with empty value (bare colon)
+      - patterns:
+          - pattern-regex: '(?m)^\s*dangerouslyAllowAllBuilds\s*:\s*$'
+    metadata:
+      category: security
+      technology:
+        - pnpm
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://pnpm.io/settings#dangerouslyallowallbuilds
+        - https://pnpm.io/settings#allowbuilds

--- a/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
+++ b/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
@@ -7,7 +7,6 @@ rules:
       `minimumReleaseAge: 10080` (minutes) to wait at least seven days before
       installing newly published package versions.
       Added in: v10.16.0
-      Reference: https://pnpm.io/settings#minimumreleaseage
     languages:
       - yaml
     severity: MEDIUM
@@ -17,7 +16,7 @@ rules:
     pattern-either:
       # Branch 1: Missing minimumReleaseAge
       - patterns:
-          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog|catalogs)\s*:)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
           - focus-metavariable: $TARGET
 
       # Branch 2: Value too low

--- a/package_managers/pnpm/pnpm-strict-dep-builds-disabled.test.yaml
+++ b/package_managers/pnpm/pnpm-strict-dep-builds-disabled.test.yaml
@@ -1,0 +1,156 @@
+---
+# ok: pnpm-strict-dep-builds-disabled
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+catalog:
+  react: ^19.0.0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: false
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: no
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: 0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: off
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds:
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+packages:
+  - "apps/*"
+strictDepBuilds: true
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+strictDepBuilds: true
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+catalogs:
+  default:
+    react: ^19.0.0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: False
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: FALSE
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: NO
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: OFF
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: yes
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: on
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: 1
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: True
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: TRUE
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: 'false'
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: 'true'
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: ~
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: null
+
+---
+# ruleid: pnpm-strict-dep-builds-disabled
+strictDepBuilds: false
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+packages:
+  - "apps/*"
+# strictDepBuilds: true
+
+---
+# ok: pnpm-strict-dep-builds-disabled
+packages:
+  - "apps/*"
+strictDepBuilds: true
+allowBuilds:
+  - esbuild
+  - sharp

--- a/package_managers/pnpm/pnpm-strict-dep-builds-disabled.yaml
+++ b/package_managers/pnpm/pnpm-strict-dep-builds-disabled.yaml
@@ -1,0 +1,49 @@
+---
+rules:
+  - id: pnpm-strict-dep-builds-disabled
+    message: >-
+      This pnpm workspace has `strictDepBuilds` disabled. When set to `false`,
+      pnpm will not exit with a non-zero code when dependencies have unreviewed
+      build scripts, silently allowing build scripts to run without triggering
+      a CI failure. The default (`true`) ensures any dependency with an
+      unapproved build script causes the install to fail, forcing explicit
+      review via the `allowBuilds` allowlist. Set `strictDepBuilds: true`
+      explicitly to restore this protection.
+      Added in: v10.3.0.
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/pnpm-workspace.yaml"
+    pattern-either:
+      # Branch 1: Key present with any value other than canonical true
+      - patterns:
+          - pattern: |
+              strictDepBuilds: $VAL
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?!true$).+'
+          - focus-metavariable: $VAL
+
+      # Branch 3: Key present with empty value (bare colon)
+      - patterns:
+          - pattern-regex: '(?m)^\s*strictDepBuilds\s*:\s*$'
+    metadata:
+      category: security
+      technology:
+        - pnpm
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://pnpm.io/settings#strictdepbuilds
+        - https://pnpm.io/settings#allowbuilds

--- a/package_managers/pnpm/pnpm-trust-policy.yaml
+++ b/package_managers/pnpm/pnpm-trust-policy.yaml
@@ -5,7 +5,6 @@ rules:
       Missing or incorrect trustPolicy. Set `trustPolicy: no-downgrade`
       to prevent malicious package updates from downgrading security settings.
       Added in: v10.21.0
-      Reference: https://pnpm.io/settings#trustpolicy
     languages:
       - yaml
     severity: MEDIUM
@@ -15,7 +14,7 @@ rules:
     pattern-either:
       # Branch 1: Missing entirely
       - patterns:
-          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog|catalogs)\s*:)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
           - focus-metavariable: $TARGET
 
       # Branch 2: Wrong value (not no-downgrade)

--- a/package_managers/renovate/renovate-missing-minimum-release-age.test.json
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.test.json
@@ -110,7 +110,7 @@
     {
       "matchPackageNames": ["webpack"],
       "groupName": "Webpack build system",
-      // ruleid: renovate-missing-minimum-release-age
+      // ok: renovate-missing-minimum-release-age
       "minimumReleaseAge": "0 days"
     },
     {

--- a/package_managers/renovate/renovate-missing-minimum-release-age.yaml
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.yaml
@@ -36,7 +36,7 @@ rules:
           - pattern-regex: '"minimumReleaseAge":\s*"(?P<AGE>\d+) days?"'
           - metavariable-comparison:
               metavariable: $AGE
-              comparison: int($AGE) < 7
+              comparison: int($AGE) > 0 and int($AGE) < 7
           - focus-metavariable: $AGE
       # Branch 3: Invalid format (not matching "N days")
       - patterns:
@@ -51,12 +51,12 @@ rules:
               regex: '^(?!\d+ days?$)'
           - focus-metavariable: $AGE
     message: >-
-      This Renovate configuration does not set a minimum release age.
+      This Renovate package rule has an insufficient or missing minimumReleaseAge.
       Newly published packages can be malicious or unstable.
-      Add `"minimumReleaseAge": "7 days"` within a `packageRules`
+      Set `"minimumReleaseAge": "7 days"` within a `packageRules`
       entry to wait 7 days before proposing updates to newly
       published package versions.
-      Set `"minimumReleaseAge": false` to set an exception for minimal release age for the package rule.
+      Use `"minimumReleaseAge": "0 days"` to explicitly opt out for trusted internal packages.
       Added in: v42
     languages:
       - json


### PR DESCRIPTION
- Update Renovate rule: flags packageRules entries missing or below-threshold minimumReleaseAge; "0 days" is allowed as an explicit opt-out for internal packages.  (Previously was `false`, which doesn't work for Renovate.  They seem to accept any flavor of `0 <span>` or just bare `0`, but for simplicity/consistency the only accepted value is the explicit `0 days`. I also can't find documentation on the bare `0`, so I don't trust it. :) )

- Add pnpm rules: `pnpm-dangerously-allow-all-builds` flags when build script approval is bypassed; `pnpm-strict-dep-builds-disabled` flags when the build script gate is turned off. Both only fire on unsafe explicit configuration since defaults are safe

- Add npm rules: `npmrc-allow-git-unrestricted` and `npmrc-allow-remote-unrestricted` flag .npmrc files missing or not setting `allow-git=none` / `allow-remote=none`.  (Recently surfaced in a GitHub blog post with those getting set to new defaults.)
