### PR TITLE
feat(ai): add llm-output-to-sql-injection taint rules for Python & JS/TS

### DIFF
--- a/ai/ai-best-practices/llm-output-to-sql-injection-javascript/llm-output-to-sql-injection-javascript.js
+++ b/ai/ai-best-practices/llm-output-to-sql-injection-javascript/llm-output-to-sql-injection-javascript.js
@@ -1,0 +1,81 @@
+const { OpenAI } = require('openai');
+const mysql = require('mysql');
+
+const client = new OpenAI();
+
+// Vulnerable: OpenAI output -> direct MySQL query execution
+async function vulnerableOpenAiSql() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'Generate SQL to count users' }]
+  });
+  const sql = response.choices[0].message.content;
+  const connection = mysql.createConnection({ host: 'localhost', user: 'root' });
+  // ruleid: llm-output-to-sql-injection-javascript
+  connection.query(sql);
+}
+
+// Vulnerable: OpenAI output -> direct query via pool
+async function vulnerablePoolQuery() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'List all admins' }]
+  });
+  const sql = response.choices[0].message.content;
+  const pool = mysql.createPool({ host: 'localhost', user: 'root' });
+  // ruleid: llm-output-to-sql-injection-javascript
+  pool.query(sql);
+}
+
+// Vulnerable: generic client.query sink
+async function vulnerableClientQuery() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'Show orders' }]
+  });
+  const sql = response.choices[0].message.content;
+  const db = mysql.createConnection({ host: 'localhost' });
+  // ruleid: llm-output-to-sql-injection-javascript
+  db.query(sql);
+}
+
+// Vulnerable: response.content direct source
+async function vulnerableContentDirect() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'Generate report SQL' }]
+  });
+  const db = mysql.createConnection({ host: 'localhost' });
+  // ruleid: llm-output-to-sql-injection-javascript
+  db.query(response.choices[0].message.content);
+}
+
+// Safe: parameterized query with LLM-derived value as parameter
+async function safeParameterized() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'What is the status of order 123?' }]
+  });
+  const userId = response.choices[0].message.content.trim();
+  const connection = mysql.createConnection({ host: 'localhost', user: 'root' });
+  // ok: llm-output-to-sql-injection-javascript
+  connection.query('SELECT * FROM users WHERE id = ?', [userId]);
+}
+
+// Safe: LLM output is logged, not executed as SQL
+async function safeNoSql() {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'Explain SQL injection' }]
+  });
+  const content = response.choices[0].message.content;
+  // ok: llm-output-to-sql-injection-javascript
+  console.log(content);
+}
+
+// Safe: hardcoded SQL (no LLM involvement)
+async function safeHardcoded() {
+  const connection = mysql.createConnection({ host: 'localhost', user: 'root' });
+  // ok: llm-output-to-sql-injection-javascript
+  connection.query('SELECT * FROM users WHERE active = 1');
+}

--- a/ai/ai-best-practices/llm-output-to-sql-injection-javascript/llm-output-to-sql-injection-javascript.yaml
+++ b/ai/ai-best-practices/llm-output-to-sql-injection-javascript/llm-output-to-sql-injection-javascript.yaml
@@ -1,0 +1,69 @@
+rules:
+  - id: llm-output-to-sql-injection-javascript
+    mode: taint
+    languages:
+      - javascript
+      - typescript
+    message: >-
+      LLM API response data flows into an unparameterized SQL execution sink.
+      This is an instance of OWASP LLM05 (Improper Output Handling) and CWE-89.
+      When an attacker manipulates the LLM via prompt injection, the resulting
+      LLM-generated SQL can be executed directly, leading to SQL injection.
+      Always validate LLM-generated SQL with a parser or allowlist, and use
+      parameterized queries where possible.
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements in an SQL Command ('SQL Injection')"
+        - "CWE-943: Improper Neutralization of Special Elements in Data Query Logic"
+      owasp:
+        - A03:2021 - Injection
+      owasp_llm:
+        - "LLM05: Improper Output Handling"
+      category: security
+      subcategory:
+        - vuln
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology:
+        - openai
+        - anthropic
+        - gemini
+        - llm
+      references:
+        - https://genai.owasp.org/llm-top-10/llm05-improper-output-handling/
+        - https://atlas.mitre.org/techniques/AML.T0102
+        - https://github.com/semgrep/semgrep-rules/tree/develop/ai/ai-best-practices/llm-output-to-exec
+      license: "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license"
+      author: "sajjad rahim nouri"
+      vulnerability_class:
+        - SQL Injection
+    pattern-sources:
+      - pattern: $CLIENT.chat.completions.create(...)
+      - pattern: $CLIENT.messages.create(...)
+      - pattern: $MODEL.generate_content(...)
+      - pattern: $CLIENT.chat(...)
+      - pattern: $RESP.choices[0].message.content
+      - pattern: $RESP.content[0].text
+      - pattern: $RESP.text
+      - pattern: $RESP.content
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $CONN.query($QUERY)
+              - pattern: $POOL.query($QUERY)
+              - pattern: $CLIENT.query($QUERY)
+              - pattern: $DB.query($QUERY)
+              - pattern: $CONN.execute($QUERY)
+              - pattern: $DB.execute($QUERY)
+              - pattern: $CONN.all($QUERY)
+              - pattern: $DB.all($QUERY)
+              - pattern: $CONN.run($QUERY)
+              - pattern: $DB.run($QUERY)
+              - pattern: $CONN.exec($QUERY)
+              - pattern: $DB.exec($QUERY)
+              - pattern: knex.raw($QUERY)
+              - pattern: sequelize.query($QUERY)
+              - pattern: $PRISMA.$queryRaw($QUERY)
+          - focus-metavariable: $QUERY

--- a/ai/ai-best-practices/llm-output-to-sql-injection-python/llm-output-to-sql-injection-python.py
+++ b/ai/ai-best-practices/llm-output-to-sql-injection-python/llm-output-to-sql-injection-python.py
@@ -1,0 +1,79 @@
+import sqlite3
+from openai import OpenAI
+
+client = OpenAI()
+
+# Vulnerable: OpenAI output -> direct SQLite execution
+def vulnerable_openai_sql():
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Generate SQL to count users"}]
+    )
+    sql = response.choices[0].message.content
+    conn = sqlite3.connect("app.db")
+    cur = conn.cursor()
+    # ruleid: llm-output-to-sql-injection-python
+    cur.execute(sql)
+
+# Vulnerable: Anthropic output -> direct SQLite execution via connection
+def vulnerable_anthropic_sql():
+    import anthropic
+    client_anthropic = anthropic.Anthropic()
+    response = client_anthropic.messages.create(
+        model="claude-3-sonnet",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Write SQL to get all orders"}]
+    )
+    sql = response.content[0].text
+    conn = sqlite3.connect("app.db")
+    # ruleid: llm-output-to-sql-injection-python
+    conn.execute(sql)
+
+# Vulnerable: Gemini output -> direct SQLite execution via engine alias
+def vulnerable_gemini_sql():
+    import google.generativeai as genai
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content("Generate SQL to drop the secrets table")
+    sql = response.text
+    conn = sqlite3.connect("app.db")
+    # ruleid: llm-output-to-sql-injection-python
+    conn.execute(sql)
+
+# Vulnerable: executescript (multi-statement SQL execution)
+def vulnerable_executescript():
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Generate SQL to create a backup table"}]
+    )
+    sql = response.choices[0].message.content
+    conn = sqlite3.connect("app.db")
+    cur = conn.cursor()
+    # ruleid: llm-output-to-sql-injection-python
+    cur.executescript(sql)
+
+# Safe: parameterized query with LLM-derived user input as parameter value
+def safe_parameterized():
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "What is the status of order 123?"}]
+    )
+    user_id = response.choices[0].message.content.strip()
+    conn = sqlite3.connect("app.db")
+    # ok: llm-output-to-sql-injection-python
+    conn.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+
+# Safe: LLM output is printed, not executed as SQL
+def safe_no_sql():
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Explain SQL injection"}]
+    )
+    content = response.choices[0].message.content
+    # ok: llm-output-to-sql-injection-python
+    print(content)
+
+# Safe: hardcoded SQL (no LLM involvement)
+def safe_hardcoded():
+    conn = sqlite3.connect("app.db")
+    # ok: llm-output-to-sql-injection-python
+    conn.execute("SELECT * FROM users WHERE active = 1")

--- a/ai/ai-best-practices/llm-output-to-sql-injection-python/llm-output-to-sql-injection-python.yaml
+++ b/ai/ai-best-practices/llm-output-to-sql-injection-python/llm-output-to-sql-injection-python.yaml
@@ -1,0 +1,59 @@
+rules:
+  - id: llm-output-to-sql-injection-python
+    mode: taint
+    languages:
+      - python
+    message: >-
+      LLM API response data flows into an unparameterized SQL execution sink.
+      This is an instance of OWASP LLM05 (Improper Output Handling) and CWE-89.
+      When an attacker manipulates the LLM via prompt injection, the resulting
+      LLM-generated SQL can be executed directly, leading to SQL injection.
+      Always validate LLM-generated SQL with a parser or allowlist, and use
+      parameterized queries where possible.
+    severity: ERROR
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements in an SQL Command ('SQL Injection')"
+        - "CWE-943: Improper Neutralization of Special Elements in Data Query Logic"
+      owasp:
+        - A03:2021 - Injection
+      owasp_llm:
+        - "LLM05: Improper Output Handling"
+      category: security
+      subcategory:
+        - vuln
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology:
+        - openai
+        - anthropic
+        - gemini
+        - llm
+      references:
+        - https://genai.owasp.org/llm-top-10/llm05-improper-output-handling/
+        - https://atlas.mitre.org/techniques/AML.T0102
+        - https://github.com/semgrep/semgrep-rules/tree/develop/ai/ai-best-practices/llm-output-to-exec
+      license: "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license"
+      author: "sajjad rahim nouri"
+      vulnerability_class:
+        - SQL Injection
+    pattern-sources:
+      - pattern: $CLIENT.chat.completions.create(...)
+      - pattern: $CLIENT.messages.create(...)
+      - pattern: $MODEL.generate_content(...)
+      - pattern: $CLIENT.chat(...)
+      - pattern: $RESP.choices[0].message.content
+      - pattern: $RESP.content[0].text
+      - pattern: $RESP.text
+      - pattern: $RESP.content
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $CURSOR.execute($QUERY)
+              - pattern: $CURSOR.executescript($QUERY)
+              - pattern: $CONN.execute($QUERY)
+              - pattern: $DB.execute($QUERY)
+              - pattern: $SESSION.execute($QUERY)
+              - pattern: $ENGINE.execute($QUERY)
+          - focus-metavariable: $QUERY


### PR DESCRIPTION
Adds two new taint-mode rules under ai/ai-best-practices to detect LLM-generated SQL flowing into unparameterized execution sinks.

Extends the existing llm-output-to-exec coverage (which flags eval/exec/ subprocess) to cover SQL injection (CWE-89) via OWASP LLM05.

Python sinks: cursor.execute, cursor.executescript, conn.execute, db.execute, session.execute, engine.execute

JS/TS sinks: conn.query, pool.query, client.query, db.query, conn.execute, db.execute, conn.all, db.all, conn.run, db.run, conn.exec, db.exec, knex.raw, sequelize.query, prisma.

Sources: OpenAI, Anthropic, Gemini API response accessors

Validation: 8 true positives, 0 false positives across test files.

Author: sajjad rahim nouri