### PR TITLE
fix(gosql-sqli): match ExecContext in method regex

### DIFF
--- a/go/lang/security/audit/sqli/gosql-sqli.go
+++ b/go/lang/security/audit/sqli/gosql-sqli.go
@@ -1,5 +1,6 @@
 package main
 
+import "context"
 import "database/sql"
 import "fmt"
 
@@ -34,6 +35,12 @@ func bad4(db *sql.DB) {
 func bad5(db *sql.DB) {
     // ruleid: gosql-sqli
     db.Exec(fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email))
+}
+
+func bad6(db *sql.DB) {
+    query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
+    // ruleid: gosql-sqli
+    db.ExecContext(context.Background(), query)
 }
 
 func ok1(db *sql.DB) {

--- a/go/lang/security/audit/sqli/gosql-sqli.yaml
+++ b/go/lang/security/audit/sqli/gosql-sqli.yaml
@@ -33,7 +33,7 @@ rules:
   - pattern-not: $DB.$METHOD(..., "..." + "...", ...)
   - metavariable-regex:
       metavariable: $METHOD
-      regex: ^(Exec|ExecContent|Query|QueryContext|QueryRow|QueryRowContext)$
+      regex: ^(Exec|ExecContext|Query|QueryContext|QueryRow|QueryRowContext)$
   languages:
   - go
   message: >-


### PR DESCRIPTION
Fixes #3694

There is a typo in the gosql-sqli method regex: it uses ExecContent instead of ExecContext, so db.ExecContext(...) calls are currently missed.

This patch updates the regex to ExecContext and adds a test case that uses ExecContext with a concatenated query to make sure the rule catches it.

I verified with:
- semgrep validate go/lang/security/audit/sqli/gosql-sqli.yaml
- semgrep test go/lang/security/audit/sqli