### PR TITLE
Add comprehensive Android WebView security rules (XSS, File Access, Universal Access)

### DIFF
--- a/java/android/security/test-webview-xss.java
+++ b/java/android/security/test-webview-xss.java
@@ -1,0 +1,13 @@
+import android.webkit.WebView;
+
+public class Test {
+    // ruleid: android-webview-javascript-enabled-xss
+    public void vulnerableWebView(WebView view) {
+        view.getSettings().setJavaScriptEnabled(true);
+    }
+
+    // ok: android-webview-javascript-enabled-xss
+    public void safeWebView(WebView view) {
+        view.getSettings().setJavaScriptEnabled(false);
+    }
+}

--- a/java/android/security/test-webview-xss.java
+++ b/java/android/security/test-webview-xss.java
@@ -2,12 +2,32 @@ import android.webkit.WebView;
 
 public class Test {
     // ruleid: android-webview-javascript-enabled-xss
-    public void vulnerableWebView(WebView view) {
+    public void vulnerableXss(WebView view) {
         view.getSettings().setJavaScriptEnabled(true);
     }
 
     // ok: android-webview-javascript-enabled-xss
-    public void safeWebView(WebView view) {
+    public void safeXss(WebView view) {
         view.getSettings().setJavaScriptEnabled(false);
+    }
+
+    // ruleid: android-webview-file-access
+    public void vulnerableFileAccess(WebView view) {
+        view.getSettings().setAllowFileAccess(true);
+    }
+
+    // ok: android-webview-file-access
+    public void safeFileAccess(WebView view) {
+        view.getSettings().setAllowFileAccess(false);
+    }
+
+    // ruleid: android-webview-universal-access
+    public void vulnerableUniversalAccess(WebView view) {
+        view.getSettings().setAllowUniversalAccessFromFileURLs(true);
+    }
+
+    // ok: android-webview-universal-access
+    public void safeUniversalAccess(WebView view) {
+        view.getSettings().setAllowUniversalAccessFromFileURLs(false);
     }
 }

--- a/java/android/security/webview-file-access.yaml
+++ b/java/android/security/webview-file-access.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: android-webview-file-access
+    message: >-
+      WebView with `setAllowFileAccess(true)` allows access to local files.
+      This can leak sensitive data if untrusted content is loaded. Disable
+      file access unless strictly necessary.
+    severity: WARNING
+    metadata:
+      category: security
+      technology:
+        - android
+        - java
+        - kotlin
+      cwe: "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+    languages:
+      - java
+      - kotlin
+    patterns:
+      - pattern-inside: |
+          $WEBVIEW.getSettings()
+      - pattern: $SETTINGS.setAllowFileAccess(true)

--- a/java/android/security/webview-javascript-enabled-xss.yaml
+++ b/java/android/security/webview-javascript-enabled-xss.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: android-webview-javascript-enabled-xss
+    message: >-
+      WebView with `setJavaScriptEnabled(true)` is vulnerable to Cross-Site Scripting (XSS)
+      if untrusted content is loaded. Disable JavaScript or ensure strict content validation.
+      Also consider disabling file access and using a WebViewClient.
+    severity: WARNING
+    metadata:
+      category: security
+      technology:
+        - android
+        - java
+        - kotlin
+      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      owasp: "A07:2017 - Cross-Site Scripting (XSS)"
+    languages:
+      - java
+      - kotlin
+    patterns:
+      - pattern-inside: |
+          $WEBVIEW.getSettings()
+      - pattern: $SETTINGS.setJavaScriptEnabled(true)

--- a/java/android/security/webview-universal-access.yaml
+++ b/java/android/security/webview-universal-access.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: android-webview-universal-access
+    message: >-
+      `setAllowUniversalAccessFromFileURLs(true)` allows file:// URLs to access
+      any origin, breaking same-origin policy. This is extremely dangerous and
+      should never be used in production.
+    severity: ERROR
+    metadata:
+      category: security
+      technology:
+        - android
+        - java
+        - kotlin
+      cwe: "CWE-668: Exposure of Resource to Wrong Sphere"
+    languages:
+      - java
+      - kotlin
+    patterns:
+      - pattern-inside: |
+          $WEBVIEW.getSettings()
+      - pattern: $SETTINGS.setAllowUniversalAccessFromFileURLs(true)


### PR DESCRIPTION
This PR adds a set of Semgrep rules targeting common security misconfigurations in Android WebView:

1. **JavaScript Enabled (XSS)** – `setJavaScriptEnabled(true)` → CWE-79
2. **File Access** – `setAllowFileAccess(true)` → CWE-200
3. **Universal Access From File URLs** – `setAllowUniversalAccessFromFileURLs(true)` → CWE-668

As a penetration tester and reverse engineer specializing in Android security, I regularly encounter these issues during assessments. These rules will help developers catch them early in the CI/CD pipeline.

All rules include a shared test case file with `ruleid` and `ok` annotations.