### PR TITLE
Add python.fastapi.security.path-traversal-file-response rule

### DIFF
--- a/python/fastapi/security/path-traversal-file-response.py
+++ b/python/fastapi/security/path-traversal-file-response.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from starlette.responses import FileResponse as StarletteFileResponse
+
+app = FastAPI()
+STATIC_DIR = Path(__file__).parent / "static"
+CACHE_DIR = "/var/app/cache"
+
+
+# True positive 1: SPA catchall with pathlib `/` join and is_file() guard.
+@app.get("/{full_path:path}")
+async def serve_spa(full_path: str):
+    candidate = STATIC_DIR / full_path
+    if candidate.is_file():
+        # ruleid: path-traversal-file-response
+        return FileResponse(candidate)
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+# True positive 2: os.path.join + sync handler.
+@app.get("/cache/{path:path}")
+def serve_cache(path: str):
+    file_path = os.path.join(CACHE_DIR, path)
+    # ruleid: path-traversal-file-response
+    return FileResponse(file_path)
+
+
+# True positive 3: multi-segment route + starlette-namespaced FileResponse +
+# .api_route decorator.
+@app.api_route("/files/{folder_name}/{file_name:path}", methods=["GET"])
+async def serve_profile_picture(folder_name: str, file_name: str):
+    target = STATIC_DIR / "profile_pictures" / folder_name / file_name
+    # ruleid: path-traversal-file-response
+    return StarletteFileResponse(target)
+
+
+# Negative 1: no `:path` modifier on route param. A bare `{name}` segment
+# cannot contain `/` per Starlette routing, so traversal via `../` is not
+# possible through this path.
+@app.get("/logo/{name}")
+async def serve_logo(name: str):
+    candidate = STATIC_DIR / f"{name}.png"
+    # ok: path-traversal-file-response
+    return FileResponse(candidate)
+
+
+# Negative 2: no route at all -- function joins static strings, no taint
+# source.
+def build_default_response():
+    candidate = STATIC_DIR / "index.html"
+    # ok: path-traversal-file-response
+    return FileResponse(candidate)

--- a/python/fastapi/security/path-traversal-file-response.yaml
+++ b/python/fastapi/security/path-traversal-file-response.yaml
@@ -1,0 +1,85 @@
+rules:
+  - id: path-traversal-file-response
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    message: >-
+      Untrusted path-parameter input from a FastAPI route is reaching a
+      `FileResponse(...)` call without an `is_relative_to()` or
+      `os.path.commonpath()` containment check. An attacker can supply `../`
+      sequences in the route variable to read arbitrary files outside the
+      intended directory. Fix by resolving the candidate and verifying
+      containment, then falling back to a safe default on mismatch:
+      `candidate = (BASE / user_path).resolve();
+      if not candidate.is_relative_to(BASE.resolve()): return safe_fallback`.
+      Note that `str.startswith(base)` without a trailing `os.sep` is a known
+      flawed guard (see CVE-2026-54014, CVE-2026-33497) and does NOT count as
+      containment.
+    metadata:
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+      owasp:
+        - A01:2021 - Broken Access Control
+        - A01:2025 - Broken Access Control
+      category: security
+      technology:
+        - python
+        - fastapi
+        - starlette
+      cwe2022-top25: true
+      cwe2021-top25: true
+      confidence: MEDIUM
+      likelihood: HIGH
+      impact: HIGH
+      vulnerability_class:
+        - Path Traversal
+      subcategory:
+        - vuln
+      references:
+        - https://cwe.mitre.org/data/definitions/22.html
+        - https://owasp.org/www-community/attacks/Path_Traversal
+        - https://github.com/advisories/GHSA-j2c8-v969-8r5c
+        - https://github.com/advisories/GHSA-vvxm-vxmr-624h
+        - https://github.com/advisories/GHSA-ph9w-r52h-28p7
+        - https://github.com/advisories/GHSA-pj2x-hxmc-9rc3
+        - https://github.com/advisories/GHSA-v5gw-mw7f-84px
+        - https://github.com/fastapi/fastapi/discussions/8259
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  @$APP.get($ROUTE, ...)
+                  def $FUNC(..., $VAR, ...):
+                      ...
+              - pattern: |
+                  @$APP.get($ROUTE, ...)
+                  async def $FUNC(..., $VAR, ...):
+                      ...
+              - pattern: |
+                  @$APP.post($ROUTE, ...)
+                  def $FUNC(..., $VAR, ...):
+                      ...
+              - pattern: |
+                  @$APP.post($ROUTE, ...)
+                  async def $FUNC(..., $VAR, ...):
+                      ...
+              - pattern: |
+                  @$APP.api_route($ROUTE, ...)
+                  def $FUNC(..., $VAR, ...):
+                      ...
+              - pattern: |
+                  @$APP.api_route($ROUTE, ...)
+                  async def $FUNC(..., $VAR, ...):
+                      ...
+          - metavariable-regex:
+              metavariable: $ROUTE
+              regex: '.*\{[^}]*:path\}.*'
+          - focus-metavariable: $VAR
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: FileResponse($X, ...)
+              - pattern: starlette.responses.FileResponse($X, ...)
+              - pattern: fastapi.responses.FileResponse($X, ...)
+          - focus-metavariable: $X

--- a/python/fastapi/security/path-traversal-file-response.yaml
+++ b/python/fastapi/security/path-traversal-file-response.yaml
@@ -13,9 +13,13 @@ rules:
       containment, then falling back to a safe default on mismatch:
       `candidate = (BASE / user_path).resolve();
       if not candidate.is_relative_to(BASE.resolve()): return safe_fallback`.
-      Note that `str.startswith(base)` without a trailing `os.sep` is a known
-      flawed guard (see CVE-2026-54014, CVE-2026-33497) and does NOT count as
-      containment.
+      Two common flawed-guard patterns do NOT count as containment:
+      (1) `str.startswith(base)` without a trailing `os.sep` permits the
+      sibling-prefix bypass (see CVE-2026-54014, CVE-2026-33497); and
+      (2) filtering for the literal string `'..'` in the input is bypassed
+      by URL-encoded variants (`%2E%2E`, `%2F`), which Starlette decodes
+      *after* route matching, so the decoded `..` segments reach the
+      handler.
     metadata:
       cwe:
         - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"


### PR DESCRIPTION
## Summary

Adds `python.fastapi.security.path-traversal-file-response`, a taint-mode rule that detects FastAPI route handlers where a path-parameter variable (declared with `{var:path}` so it can contain `/`) reaches `FileResponse(...)` without intervening canonicalization. This is CWE-22 path traversal: an attacker can supply `../` sequences in the route variable to read arbitrary files outside the intended directory.

## Why a new rule

The closest existing precedents do not cover this case:

- `python/flask/security/injection/path-traversal-open.yaml` is the structural twin, but Flask has no `:path` route-modifier syntax and its sink is `open()` not `FileResponse(...)`.
- `python/django/security/injection/request-data-fileresponse.yaml` matches `request.GET[...]` sources into `FileResponse`, not FastAPI's signature-based path parameter injection.
- The `auto`, `p/security-audit`, and `p/owasp-top-ten` packs do not catch the FastAPI catchall + `FileResponse` shape today.

## Why this matters

This is a recurring CWE-22 pattern across the FastAPI ecosystem:

| Advisory | Project | Shape |
|---|---|---|
| [GHSA-j2c8-v969-8r5c](https://github.com/advisories/GHSA-j2c8-v969-8r5c) (CVE-2026-54014) | open-webui | `@app.get('/cache/{path:path}')` + `os.path.join` + `FileResponse`; flawed `startswith` guard |
| [GHSA-vvxm-vxmr-624h](https://github.com/advisories/GHSA-vvxm-vxmr-624h) (CVE-2026-28786) | open-webui | Same `/cache/{path:path}` shape, different exploit vector |
| [GHSA-ph9w-r52h-28p7](https://github.com/advisories/GHSA-ph9w-r52h-28p7) (CVE-2026-33497) | langflow | Multi-segment route + pathlib join + flawed `startswith` guard |
| [GHSA-pj2x-hxmc-9rc3](https://github.com/advisories/GHSA-pj2x-hxmc-9rc3) (CVE-2026-29871) | awesome-llm-apps | FastAPI stream-audio endpoint, no canonicalization |
| [GHSA-v5gw-mw7f-84px](https://github.com/advisories/GHSA-v5gw-mw7f-84px) (CVE-2023-29159) | starlette (StaticFiles) | Framework-level precedent; fixed in 0.27.0 by switching from `os.path.commonprefix` to `os.path.commonpath` |

FastAPI 0.138.0 (2026-06-20) shipped `app.frontend()` as the safer first-party replacement for the SPA-catchall + `FileResponse` pattern. This rule helps existing deployments find legacy unsafe code.

## Rule behavior

- **Source:** route-handler function parameter (sync or async) for any `@app.get`, `@app.post`, or `@app.api_route` decorator whose route string contains `{...:path}`.
- **Sink:** `FileResponse(...)`, `fastapi.responses.FileResponse(...)`, or `starlette.responses.FileResponse(...)`, with `focus-metavariable` on the path argument.
- **Not flagged:** bare `{name}` route params (no `:path`) are not sources, since Starlette routing forbids `/` in those segments, so traversal is structurally impossible.

## Test cases

3 true positives covering: pathlib `/` join with `is_file()` guard, `os.path.join` + sync handler, multi-segment route + starlette-namespaced `FileResponse`. 2 true negatives covering: route without `:path` modifier, no-route helper function with no taint source.

Validated with `semgrep test --config python/fastapi/security/path-traversal-file-response.yaml python/fastapi/security/path-traversal-file-response.py`: 3/3 true positives fired, 0/2 true negatives fired.

## Notes

This is a shape-based detection. Control-flow `is_relative_to(...)` and `os.path.commonpath(...)` guards are not modeled as taint sanitizers; the existing `python/flask/security/injection/path-traversal-open.yaml` rule follows the same convention. Users should triage flagged handlers and verify their containment check is correct. Note that `str.startswith(base)` without a trailing `os.sep` is a known flawed guard (see CVE-2026-54014 and CVE-2026-33497) and does not count as containment.