### PR TITLE
fix(php): extend symfony-non-literal-redirect with RedirectResponse and setTargetUrl patterns

### DIFF
--- a/csharp/dotnet/security/audit/xpath-injection.cs
+++ b/csharp/dotnet/security/audit/xpath-injection.cs
@@ -1,4 +1,4 @@
-public List<Knowledge> Search(string input)
+public List<Knowledge> Search1(string input)
 {
     List<Knowledge> searchResult = new List<Knowledge>();
     var webRoot = _env.WebRootPath;
@@ -11,8 +11,8 @@ public List<Knowledge> Search(string input)
     // ruleid: xpath-injection
     XPathExpression expr = nav.Compile(@"//knowledge[tags[contains(text(),'" + input + "')] and sensitivity/text() ='Public']");
 }
-
-public List<Knowledge> Search(string input)
+ 
+public List<Knowledge> Search2(string input)
 {
     List<Knowledge> searchResult = new List<Knowledge>();
     //string input;
@@ -27,4 +27,62 @@ public List<Knowledge> Search(string input)
     XPathExpression expr = nav.Compile(@"//knowledge[tags[contains(text(),'keyword')] and sensitivity/text() ='Public']");
     
     var matchedNodes = nav.Select(expr);
+}
+ 
+public List<Knowledge> Search3(string input)
+{
+    List<Knowledge> searchResult = new List<Knowledge>();
+    var webRoot = _env.WebRootPath;
+    var file = System.IO.Path.Combine(webRoot, "Knowledgebase.xml");
+ 
+    XmlDocument xmlDoc = new XmlDocument();
+    xmlDoc.Load(file);
+ 
+    XPathNavigator nav = xmlDoc.CreateNavigator();
+    // ruleid: xpath-injection
+    XPathExpression expr = nav.Compile($@"//knowledge[tags[contains(text(),'{input}')] and sensitivity/text()='Public']");
+ 
+    XPathNodeIterator nodes = nav.Select(expr);
+}
+ 
+public List<Knowledge> Search4(string input)
+{
+    List<Knowledge> searchResult = new List<Knowledge>();
+    var webRoot = _env.WebRootPath;
+    var file = System.IO.Path.Combine(webRoot,"Knowledgebase.xml");
+    
+    XmlDocument XmlDoc = new XmlDocument();
+    XmlDoc.Load(file);    
+    
+    XPathNavigator nav = XmlDoc.CreateNavigator();
+    // ruleid: xpath-injection
+    Object expr = nav.Select(@"//knowledge[tags[contains(text(),'" + input + "')] and sensitivity/text() ='Public']");
+}
+ 
+public List<Knowledge> Search5(string input)
+{
+    List<Knowledge> searchResult = new List<Knowledge>();
+    var webRoot = _env.WebRootPath;
+    var file = System.IO.Path.Combine(webRoot,"Knowledgebase.xml");
+    
+    XmlDocument XmlDoc = new XmlDocument();
+    XmlDoc.Load(file);    
+    
+    XPathNavigator nav = XmlDoc.CreateNavigator();
+    // ruleid: xpath-injection
+    var expr = nav.Select($@"//knowledge[tags[contains(text(),'{input}')] and sensitivity/text()='Public']");
+}
+ 
+public List<Knowledge> Search6(string input)
+{
+    List<Knowledge> searchResult = new List<Knowledge>();
+    var webRoot = _env.WebRootPath;
+    var file = System.IO.Path.Combine(webRoot,"Knowledgebase.xml");
+    
+    XmlDocument XmlDoc = new XmlDocument();
+    XmlDoc.Load(file);    
+    
+    XPathNavigator nav = XmlDoc.CreateNavigator();
+    // ruleid: xpath-injection
+    var expr = nav.SelectSingleNode($@"//knowledge[tags[contains(text(),'{input}')] and sensitivity/text()='Public']");
 }

--- a/csharp/dotnet/security/audit/xpath-injection.yaml
+++ b/csharp/dotnet/security/audit/xpath-injection.yaml
@@ -20,6 +20,9 @@ rules:
     - vuln
     technology:
     - .net
+    license: Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license
+    vulnerability_class:
+    - XPath Injection
   languages:
   - csharp
   mode: taint
@@ -31,7 +34,14 @@ rules:
   - pattern-either:
     - pattern: XPathExpression $EXPR = $NAV.Compile("..." + $INPUT + "...");
     - pattern: var $EXPR = $NAV.Compile("..." + $INPUT + "...");
+    - pattern: XPathExpression $EXPR = $NAV.Compile($"...{$INPUT}...");
+    - pattern: var $EXPR = $NAV.Compile($"...{$INPUT}...");
     - pattern: XPathNodeIterator $NODE = $NAV.Select("..." + $INPUT + "...");
     - pattern: var $NODE = $NAV.Select("..." + $INPUT + "...");
+    - pattern: Object $OBJ = $NAV.Select("..." + $INPUT + "...");
+    - pattern: var $NODE = $NAV.Select($"...{$INPUT}...");
+    - pattern: var $NODE = $NAV.SelectSingleNode("..." + $INPUT + "...");
+    - pattern: var $NODE = $NAV.SelectSingleNode($"...{$INPUT}...");
     - pattern: Object $OBJ = $NAV.Evaluate("..." + $INPUT + "...");
     - pattern: var $OBJ = $NAV.Evaluate("..." + $INPUT + "...");
+    - pattern: var $OBJ = $NAV.Evaluate($"...{$INPUT}...");

--- a/php/symfony/security/audit/symfony-non-literal-redirect.php
+++ b/php/symfony/security/audit/symfony-non-literal-redirect.php
@@ -17,6 +17,22 @@ class WebAppController
         return $this->redirect('https://'. $addr);
     }
 
+    public function test3(): RedirectResponse
+    {
+        $url = $request->query->get('url');
+        // ruleid: symfony-non-literal-redirect
+        return new RedirectResponse($url);
+    }
+
+    public function test4(): RedirectResponse
+    {
+        $url = $request->query->get('url');
+        $response = new RedirectResponse('/');
+        // ruleid: symfony-non-literal-redirect
+        $response->setTargetUrl($url);
+        return $response;
+    }
+
     public function okTest1(): RedirectResponse
     {
         $foobar = $session->get('foobar');
@@ -36,4 +52,17 @@ class WebAppController
         return $this->redirect();
     }
 
+    public function okTest4(): RedirectResponse
+    {
+        // ok: symfony-non-literal-redirect
+        return new RedirectResponse('http://symfony.com/doc');
+    }
+
+    public function okTest5(): RedirectResponse
+    {
+        $response = new RedirectResponse('/');
+        // ok: symfony-non-literal-redirect
+        $response->setTargetUrl('http://symfony.com/doc');
+        return $response;
+    }
 }

--- a/php/symfony/security/audit/symfony-non-literal-redirect.yaml
+++ b/php/symfony/security/audit/symfony-non-literal-redirect.yaml
@@ -1,9 +1,27 @@
 rules:
 - id: symfony-non-literal-redirect
   patterns:
-  - pattern: $this->redirect(...)
-  - pattern-not: $this->redirect("...")
-  - pattern-not: $this->redirect()
+  - pattern-either:
+    - patterns:
+      - pattern: $this->redirect(...)
+      - pattern-not: $this->redirect("...")
+      - pattern-not: $this->redirect()
+    - patterns:
+      - pattern: new RedirectResponse(...)
+      - pattern-not: new RedirectResponse("...")
+    - patterns:
+      - pattern: $RESPONSE->setTargetUrl(...)
+      - pattern-not: $RESPONSE->setTargetUrl("...")
+  - pattern-either:
+    - pattern-inside: |
+        use Symfony\Component\HttpFoundation\RedirectResponse;
+        ...
+    - pattern-inside: |
+        use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        ...
+    - pattern-inside: |
+        use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+        ...
   message: >-
     The `redirect()` method does not check its destination in any way. If you redirect to a URL provided
     by end-users, your
@@ -27,4 +45,7 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: LOW
+    license: Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license
+    vulnerability_class:
+    - Open Redirect
   severity: WARNING


### PR DESCRIPTION
## Summary

Extends the existing `php.symfony.security.audit.symfony-non-literal-redirect` rule 
with missing sink patterns that were not covered by the original rule.

## Problem

The original rule only covered `$this->redirect()` but missed two common patterns 
for open redirect vulnerabilities in Symfony:

- `new RedirectResponse($url)` — direct instantiation without controller helper
- `$response->setTargetUrl($url)` — modifying redirect target after instantiation

Both patterns are equally dangerous and widely used in Symfony applications.

## Changes

### symfony-non-literal-redirect.yaml
- Added `new RedirectResponse(...)` as a sink with literal string exclusion
- Added `$RESPONSE->setTargetUrl(...)` as a sink with literal string exclusion
- Added `pattern-inside` guards for Symfony imports to reduce FP rate
- Added `vulnerability_class: Open Redirect` to metadata

### symfony-non-literal-redirect.php
- Added `test3` — `ruleid` for `new RedirectResponse($url)`
- Added `test4` — `ruleid` for `setTargetUrl($url)`
- Added `okTest4` — `ok` for `new RedirectResponse("literal")`
- Added `okTest5` — `ok` for `setTargetUrl("literal")`
- Preserved all original test cases unchanged

## Test Plan

- [x] semgrep --validate passes
- [x] semgrep --test passes (3/3 tests)