### PR TITLE
Broaden syntax allowed by uv cooldown rule

### DIFF
--- a/package_managers/uv/uv-missing-dependency-cooldown.test.toml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.test.toml
@@ -27,5 +27,45 @@ exclude-newer = "3 days"
 exclude-newer = "banana"
 
 [tool.uv]
-# ok: uv-missing-dependency-cooldown
+# ruleid: uv-missing-dependency-cooldown
 exclude-newer = "2025-01-15T00:00:00Z"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "2025-01-15"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "6 days"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "23 hours"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "P3D"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "1 week"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "2 weeks"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "1 month"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "1 year"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "P1W"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "2 weeks 3 days"

--- a/package_managers/uv/uv-missing-dependency-cooldown.yaml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.yaml
@@ -12,18 +12,20 @@ rules:
 
       # Branch 2: Value too low (< 7 days)
       - patterns:
-          - pattern-regex: 'exclude-newer\s*=\s*"(?P<DAYS>\d+) days?"'
+          - pattern-regex: 'exclude-newer\s*=\s*"(?P<DAYS>\d+)\s*d(?:ays?)?"'
           - metavariable-comparison:
               metavariable: $DAYS
               comparison: int($DAYS) < 7
           - focus-metavariable: $DAYS
 
-      # Branch 3: Invalid format (not days, date, or timestamp)
+      # Branch 3: Not a recognized relative cooldown -> flag. Concrete
+      # dates/timestamps are intentionally rejected: a fixed date can't be
+      # verified to provide an ongoing >= 7-day cooldown.
       - patterns:
           - pattern-regex: 'exclude-newer\s*=\s*"(?P<VAL>[^"]+)"'
           - metavariable-regex:
               metavariable: $VAL
-              regex: '^(?!\d+ days?$)(?!\d{4}-\d{2}-\d{2}$)(?!\d{4}-\d{2}-\d{2}T)'
+              regex: '(?i)^(?!\d+\s*d(?:ays?)?\b)(?!\d+\s*(?:weeks?|wks?|w|months?|mos?|mo|years?|yrs?|y)\b)(?!P[^Tt]*[WMY])(?!P(?:[7-9]|[1-9]\d+)D\b)'
           - focus-metavariable: $VAL
     message: >-
       This pyproject.toml configures uv but does not set a dependency cooldown.


### PR DESCRIPTION
Our internal fleet-wide Claude Code config tells Claude to use "1 week" to specify a cooldown, but as it stands, this rule accepts a cooldown only specified in "days." This updates the rule to also allow the "d" abbreviation and accept any cooldown specified in weeks, months, or years, since any nonnegative integer of those will meet or exceed the 7 day requirement.