### PR TITLE
Add LangChain agent-tool security rules (ShellTool, PythonREPL)

### DIFF
--- a/python/langchain/security/langchain-python-repl.py
+++ b/python/langchain/security/langchain-python-repl.py
@@ -1,0 +1,64 @@
+"""Test cases for langchain-python-repl rule."""
+
+from langchain_experimental.utilities.python import PythonREPL
+from langchain_experimental.tools.python.tool import PythonREPLTool, PythonAstREPLTool
+from langchain_experimental.tools import PythonREPLTool as PythonREPLToolAlt
+import langchain_experimental.tools.python.tool
+import subprocess
+import json
+
+
+def build_unsafe_repl_agent(llm):
+    # ruleid: langchain-python-repl
+    repl = PythonREPL()
+    tools = [repl]
+    return tools
+
+
+def build_unsafe_repl_tool(llm):
+    # ruleid: langchain-python-repl
+    tool = PythonREPLTool()
+    return tool
+
+
+def build_unsafe_ast_repl(llm, df):
+    # ruleid: langchain-python-repl
+    tool = PythonAstREPLTool(locals={"df": df})
+    return tool
+
+
+def build_unsafe_full_import(llm):
+    # ruleid: langchain-python-repl
+    tool = langchain_experimental.tools.python.tool.PythonREPLTool()
+    return tool
+
+
+def build_safe_subprocess_executor(code: str):
+    """
+    Safe alternative: send code to an isolated subprocess with a timeout.
+    Real deployments should add seccomp/gVisor/Firecracker on top of this.
+    """
+    # ok: langchain-python-repl
+    proc = subprocess.run(
+        ["python3", "-c", code],
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+    return proc.stdout.decode("utf-8", errors="replace")
+
+
+def build_safe_jupyter_kernel_call(code: str, kernel_url: str, token: str):
+    """
+    Safe alternative: hand code off to a dedicated code-execution
+    service (ephemeral Jupyter kernel per session).
+    """
+    # ok: langchain-python-repl
+    import requests
+    resp = requests.post(
+        f"{kernel_url}/execute",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"code": code},
+        timeout=10,
+    )
+    return resp.json()

--- a/python/langchain/security/langchain-python-repl.yaml
+++ b/python/langchain/security/langchain-python-repl.yaml
@@ -1,0 +1,45 @@
+rules:
+- id: langchain-python-repl
+  metadata:
+    owasp:
+    - A03:2021 - Injection
+    - A03:2025 - Injection
+    cwe:
+    - 'CWE-94: Improper Control of Generation of Code'
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code'
+    references:
+    - https://python.langchain.com/docs/security/
+    - https://python.langchain.com/api_reference/experimental/tools/langchain_experimental.tools.python.tool.PythonREPLTool.html
+    category: security
+    technology:
+    - python
+    - langchain
+    - llm
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: LOW
+    vulnerability_class:
+    - Code Injection
+  languages:
+    - python
+  message: >-
+    `PythonREPLTool`, `PythonAstREPLTool`, and the underlying
+    `PythonREPL` primitive execute language-model output as Python
+    inside the host process. The default constructor does not sandbox
+    the execution. Passing a `globals` or `locals` dict does not
+    sandbox either, as dunder traversal reaches the builtins.
+    Instead, run tool calls in a subprocess with `seccomp`, `gVisor`,
+    or `Firecracker`, or hand the code off to a dedicated
+    code-execution service (an ephemeral Jupyter kernel per session).
+    Do not rely on the `globals={}` argument as a security boundary.
+  severity: WARNING
+  patterns:
+  - pattern-either:
+    - pattern: PythonREPL(...)
+    - pattern: PythonREPLTool(...)
+    - pattern: PythonAstREPLTool(...)
+    - pattern: langchain_experimental.tools.python.tool.PythonREPLTool(...)
+    - pattern: langchain_experimental.utilities.python.PythonREPL(...)
+    - pattern: langchain_experimental.tools.PythonREPLTool(...)

--- a/python/langchain/security/langchain-shell-tool.py
+++ b/python/langchain/security/langchain-shell-tool.py
@@ -1,0 +1,51 @@
+from langchain_community.tools import ShellTool
+from langchain_community.tools.shell.tool import ShellTool as ShellToolAliased
+from langchain_experimental.llm_bash.bash import BashProcess
+
+
+def build_agent_with_shell(llm):
+    # Binds the shell tool to the agent with no argv allowlist and no
+    # process isolation. Any LLM output that shapes the tool argument
+    # runs on the host.
+    # ruleid: langchain-shell-tool
+    tool = ShellTool()
+    return create_react_agent(llm, [tool])
+
+
+def build_agent_with_aliased_shell(llm):
+    # ruleid: langchain-shell-tool
+    tool = ShellToolAliased()
+    return create_react_agent(llm, [tool])
+
+
+def build_agent_with_bash_process(llm):
+    # ruleid: langchain-shell-tool
+    proc = BashProcess()
+    return create_react_agent(llm, [proc])
+
+
+def build_agent_with_fq_path(llm):
+    import langchain_community
+    # ruleid: langchain-shell-tool
+    tool = langchain_community.tools.ShellTool()
+    return create_react_agent(llm, [tool])
+
+
+# ---- true negative: a purpose-built allowlisted subprocess wrapper ----
+
+
+import subprocess
+
+ALLOWED_COMMANDS = {"ls", "cat", "wc"}
+
+
+def allowlisted_shell(argv):
+    if not argv or argv[0] not in ALLOWED_COMMANDS:
+        raise ValueError("command not permitted")
+    # ok: langchain-shell-tool
+    return subprocess.run(argv, capture_output=True, text=True, timeout=5)
+
+
+def create_react_agent(llm, tools):
+    # placeholder so the file is importable
+    return (llm, tools)

--- a/python/langchain/security/langchain-shell-tool.yaml
+++ b/python/langchain/security/langchain-shell-tool.yaml
@@ -1,0 +1,47 @@
+rules:
+- id: langchain-shell-tool
+  metadata:
+    owasp:
+    - A03:2021 - Injection
+    - A03:2025 - Injection
+    cwe:
+    - 'CWE-77: Improper Neutralization of Special Elements used in a Command'
+    - 'CWE-78: OS Command Injection'
+    references:
+    - https://python.langchain.com/docs/security/
+    - https://python.langchain.com/api_reference/community/tools/langchain_community.tools.shell.tool.ShellTool.html
+    category: security
+    technology:
+    - python
+    - langchain
+    - llm
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: LOW
+    vulnerability_class:
+    - Command Injection
+  languages:
+    - python
+  message: >-
+    LangChain `ShellTool`, `BashProcess`, and `TerminalTool` execute
+    strings emitted by a language model against the system shell.
+    When the tool is bound to an agent without an explicit command
+    allowlist and without process isolation, any prompt or context
+    that reaches the model can produce arbitrary command execution on
+    the host running the agent.
+    Instead, wrap shell access in a purpose-built tool that (1) accepts
+    a structured argument (not a free-form string), (2) validates
+    `argv[0]` against an allowlist, and (3) runs inside a container
+    with a read-only filesystem and no outbound network. Do not rely
+    on prompt-level instructions to constrain command output.
+  severity: WARNING
+  patterns:
+  - pattern-either:
+    - pattern: ShellTool(...)
+    - pattern: BashProcess(...)
+    - pattern: TerminalTool(...)
+    - pattern: langchain_community.tools.ShellTool(...)
+    - pattern: langchain_community.tools.shell.tool.ShellTool(...)
+    - pattern: langchain_experimental.llm_bash.bash.BashProcess(...)


### PR DESCRIPTION
## What this adds

Two new Python rules covering LangChain agent-tool security patterns that are not currently covered anywhere in this repository.

### 1. `python.langchain.security.langchain-shell-tool`

`ShellTool`, `BashProcess`, and `TerminalTool` from `langchain_community.tools` execute shell strings emitted by a language model against the host system. Without an explicit command allowlist and process isolation, binding one of these tools to an agent is a direct prompt-to-shell path. This is the first LangChain-specific security rule in the registry.

- CWE-77, CWE-78
- likelihood: MEDIUM, impact: HIGH, confidence: LOW
- 4 true-positive + 1 true-negative test cases

### 2. `python.langchain.security.langchain-python-repl`

`PythonREPLTool`, `PythonAstREPLTool`, and the underlying `PythonREPL` primitive execute LLM-generated Python inside the host process. The default constructor does not sandbox. Passing a `globals` or `locals` dict is not a security boundary because dunder traversal reaches the builtins. The safe pattern is subprocess isolation with `seccomp` / `gVisor` / `Firecracker`, or delegation to a dedicated code-execution service.

- CWE-94, CWE-95
- likelihood: MEDIUM, impact: HIGH, confidence: LOW
- 4 true-positive + 2 true-negative test cases

## Tests

Each rule has a matching `.py` test file with both `# ruleid:` (true-positive) and `# ok:` (true-negative) annotations. Both pass `semgrep --test`:

```
1/1: ✓ All tests passed
```

## Notes

- Namespacing: `python/langchain/security/`, matching the framework-first convention used elsewhere for framework-specific rules.
- Metadata is filled in per the contributor guide: `cwe`, `owasp`, `confidence`, `likelihood`, `impact`, `subcategory: [audit]`, `vulnerability_class`, `technology`, `references`.
- Each message follows the description → why → alternative pattern.
- CLA will be signed on this PR.

## Changelog

- Original PR also included `avoid-joblib-load`. Dropped after the Semgrep AppSec bot flagged that `trailofbits.python.scikit-joblib-load` in this repo already covers that pattern. Rebased the branch to remove that commit.