### PR TITLE
Add FastAPI TrustedHost rule

### DIFF
--- a/python/fastapi/security/unrestricted-trusted-host.py
+++ b/python/fastapi/security/unrestricted-trusted-host.py
@@ -1,0 +1,190 @@
+from fastapi import FastAPI
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from starlette.middleware import Middleware
+
+app = FastAPI()
+
+wildcard_hosts = ["*"]
+trusted_hosts = ["example.com", "*.example.com"]
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=["*"],
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=wildcard_hosts,
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    www_redirect=False,
+    allowed_hosts=["*"],
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    ["*"],
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    wildcard_hosts,
+)
+
+# ok: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=trusted_hosts,
+)
+
+# ok: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    www_redirect=False,
+    allowed_hosts=trusted_hosts,
+)
+
+# ok: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=["example.com", "*.example.com"],
+)
+
+# ok: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    trusted_hosts,
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+)
+
+# ruleid: unrestricted-trusted-host
+app.add_middleware(
+    TrustedHostMiddleware,
+    www_redirect=False,
+)
+
+app_from_middleware = FastAPI(
+    middleware=[
+        # ruleid: unrestricted-trusted-host
+        Middleware(
+            TrustedHostMiddleware,
+            allowed_hosts=["*"],
+        )
+    ]
+)
+
+app_from_positional_middleware = FastAPI(
+    middleware=[
+        # ruleid: unrestricted-trusted-host
+        Middleware(
+            TrustedHostMiddleware,
+            ["*"],
+        )
+    ]
+)
+
+configured_middleware = [
+    # ruleid: unrestricted-trusted-host
+    Middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=wildcard_hosts,
+    )
+]
+app_from_configured_middleware = FastAPI(middleware=configured_middleware)
+
+safe_middleware = [
+    # ok: unrestricted-trusted-host
+    Middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=["example.com", "*.example.com"],
+    )
+]
+
+app_from_safe_middleware = FastAPI(middleware=safe_middleware)
+
+safe_positional_middleware = [
+    # ok: unrestricted-trusted-host
+    Middleware(
+        TrustedHostMiddleware,
+        trusted_hosts,
+    )
+]
+
+app_from_safe_positional_middleware = FastAPI(middleware=safe_positional_middleware)
+
+missing_hosts_middleware = [
+    # ruleid: unrestricted-trusted-host
+    Middleware(
+        TrustedHostMiddleware,
+    )
+]
+app_from_missing_hosts_middleware = FastAPI(middleware=missing_hosts_middleware)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    allowed_hosts=["*"],
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    wildcard_hosts,
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app=app,
+    allowed_hosts=["*"],
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    www_redirect=False,
+    allowed_hosts=["*"],
+)
+
+# ok: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    allowed_hosts=["example.com"],
+)
+
+# ok: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    trusted_hosts,
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app=app,
+)
+
+# ruleid: unrestricted-trusted-host
+app = TrustedHostMiddleware(
+    app,
+    www_redirect=False,
+)
+
+
+@app.get("/")
+async def main():
+    return {"message": "Hello Semgrep"}

--- a/python/fastapi/security/unrestricted-trusted-host.yaml
+++ b/python/fastapi/security/unrestricted-trusted-host.yaml
@@ -1,0 +1,172 @@
+rules:
+  - id: unrestricted-trusted-host
+    languages:
+      - python
+    message: TrustedHostMiddleware allows any host. Configure allowed_hosts with
+      explicit trusted hostnames.
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $APP.add_middleware(
+                TrustedHostMiddleware,
+                ...,
+                allowed_hosts=[..., "*", ...],
+                ...)
+          - pattern: |
+              Middleware(
+                TrustedHostMiddleware,
+                ...,
+                allowed_hosts=[..., "*", ...],
+                ...)
+          - pattern: |
+              TrustedHostMiddleware(
+                $APP,
+                ...,
+                allowed_hosts=[..., "*", ...],
+                ...)
+          - pattern: |
+              TrustedHostMiddleware(
+                app=$APP,
+                ...,
+                allowed_hosts=[..., "*", ...],
+                ...)
+          - pattern: |
+              Middleware(
+                TrustedHostMiddleware,
+                [..., "*", ...],
+                ...)
+          - pattern: |
+              $APP.add_middleware(
+                TrustedHostMiddleware,
+                [..., "*", ...],
+                ...)
+          - pattern: |
+              TrustedHostMiddleware(
+                $APP,
+                [..., "*", ...],
+                ...)
+          - patterns:
+              - pattern-inside: |
+                  $HOSTS = [..., "*", ...]
+                  ...
+              - pattern-either:
+                  - pattern: |
+                      $APP.add_middleware(
+                        TrustedHostMiddleware,
+                        ...,
+                        allowed_hosts=$HOSTS,
+                        ...)
+                  - pattern: |
+                      Middleware(
+                        TrustedHostMiddleware,
+                        ...,
+                        allowed_hosts=$HOSTS,
+                        ...)
+                  - pattern: |
+                      TrustedHostMiddleware(
+                        $APP,
+                        ...,
+                        allowed_hosts=$HOSTS,
+                        ...)
+                  - pattern: |
+                      TrustedHostMiddleware(
+                        app=$APP,
+                        ...,
+                        allowed_hosts=$HOSTS,
+                        ...)
+                  - pattern: |
+                      Middleware(
+                        TrustedHostMiddleware,
+                        $HOSTS,
+                        ...)
+                  - pattern: |
+                      $APP.add_middleware(
+                        TrustedHostMiddleware,
+                        $HOSTS,
+                        ...)
+                  - pattern: |
+                      TrustedHostMiddleware(
+                        $APP,
+                        $HOSTS,
+                        ...)
+          - patterns:
+              - pattern: |
+                  $APP.add_middleware(
+                    TrustedHostMiddleware,
+                    ...)
+              - pattern-not: |
+                  $APP.add_middleware(
+                    TrustedHostMiddleware,
+                    ...,
+                    allowed_hosts=$HOSTS,
+                    ...)
+              - pattern-not: |
+                  $APP.add_middleware(
+                    TrustedHostMiddleware,
+                    $HOSTS,
+                    ...)
+          - patterns:
+              - pattern: |
+                  Middleware(
+                    TrustedHostMiddleware,
+                    ...)
+              - pattern-not: |
+                  Middleware(
+                    TrustedHostMiddleware,
+                    ...,
+                    allowed_hosts=$HOSTS,
+                    ...)
+              - pattern-not: |
+                  Middleware(
+                    TrustedHostMiddleware,
+                    $HOSTS,
+                    ...)
+          - patterns:
+              - pattern: |
+                  TrustedHostMiddleware(
+                    $APP,
+                    ...)
+              - pattern-not: |
+                  TrustedHostMiddleware(
+                    $APP,
+                    ...,
+                    allowed_hosts=$HOSTS,
+                    ...)
+              - pattern-not: |
+                  TrustedHostMiddleware(
+                    $APP,
+                    $HOSTS,
+                    ...)
+          - patterns:
+              - pattern: |
+                  TrustedHostMiddleware(
+                    app=$APP,
+                    ...)
+              - pattern-not: |
+                  TrustedHostMiddleware(
+                    app=$APP,
+                    ...,
+                    allowed_hosts=$HOSTS,
+                    ...)
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-940: Improper Verification of Source of a Communication Channel"
+      owasp:
+        - A05:2021 - Security Misconfiguration
+        - A02:2025 - Security Misconfiguration
+      category: security
+      technology:
+        - python
+        - fastapi
+      references:
+        - https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+        - https://fastapi.tiangolo.com/advanced/middleware/#trustedhostmiddleware
+        - https://starlette.dev/middleware/#trustedhostmiddleware
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: MEDIUM
+      vulnerability_class:
+        - Configuration
+      subcategory:
+        - audit


### PR DESCRIPTION
Similar to #3988, this adds FastAPI middleware coverage for TrustedHostMiddleware when allowed_hosts allows any host or is missing.

Tests:
- make SEMGREP=semgrep test