### PR TITLE
Detect insecure BuildKit RUN steps

### DIFF
--- a/dockerfile/security/run-security-insecure.dockerfile
+++ b/dockerfile/security/run-security-insecure.dockerfile
@@ -1,0 +1,27 @@
+FROM alpine
+
+# ok: run-security-insecure
+RUN true
+
+# ok: run-security-insecure
+RUN --security=sandbox true
+
+# ok: run-security-insecure
+RUN echo --security=insecure
+
+# ruleid: run-security-insecure
+RUN --security=insecure cat /proc/self/status
+
+# ruleid: run-security-insecure
+RUN --security=insecure ["cat", "/proc/self/status"]
+
+# ruleid: run-security-insecure
+RUN --mount=type=cache,target=/root/.cache --security=insecure make build
+
+# ruleid: run-security-insecure
+RUN --network=none --security=insecure make build
+
+# ruleid: run-security-insecure
+RUN --mount=type=cache,target=/root/.cache \
+    --security=insecure \
+    make build

--- a/dockerfile/security/run-security-insecure.yaml
+++ b/dockerfile/security/run-security-insecure.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: run-security-insecure
+  patterns:
+  - pattern-regex: '(?m)^\s*RUN\s+(?:(?:--(?:device|mount|network)=[^\s\\]+|\\)\s+)*--security=insecure(?:\s|\\|$)'
+  message: >-
+    BuildKit's RUN --security=insecure runs this build step without the normal
+    sandbox, equivalent to privileged container execution. Avoid insecure build
+    entitlements unless the build step truly needs them.
+  metadata:
+    cwe:
+    - 'CWE-250: Execution with Unnecessary Privileges'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    - A02:2025 - Security Misconfiguration
+    references:
+    - https://docs.docker.com/reference/dockerfile/#run---security
+    category: security
+    technology:
+    - dockerfile
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: HIGH
+    confidence: HIGH
+  languages:
+  - dockerfile
+  severity: WARNING


### PR DESCRIPTION
RUN --security=insecure disables the normal BuildKit sandbox for a build step and is equivalent to privileged container execution. This flags the insecure entitlement while ignoring sandbox mode and command arguments that only contain the same text.

Tests:
- semgrep test dockerfile/security
- make SEMGREP=semgrep test