### PR TITLE
fix(sonarqube): detected-sonarqube-docs-api-key false-positives on SHA pins / image digests

### DIFF
--- a/generic/secrets/security/detected-sonarqube-docs-api-key.txt
+++ b/generic/secrets/security/detected-sonarqube-docs-api-key.txt
@@ -1,2 +1,20 @@
 # ruleid: detected-sonarqube-docs-api-key
 SONARQUBE=5eeee8e4deeee2dbfeeeedbeeeec37b7eeeea7b9
+# ruleid: detected-sonarqube-docs-api-key
+sonar.login=e884618bb0f2ca8744f5b5e0e6f9d2f61bce7e8f
+# ruleid: detected-sonarqube-docs-api-key
+sonar.token: "1234567890abcdef1234567890abcdef12345678"
+# ruleid: detected-sonarqube-docs-api-key
+SONAR_TOKEN = abcdef01234567890abcdef01234567890abcdef
+
+# The following are NOT SonarQube API keys — a 40-char git commit SHA or an
+# image digest that merely co-occurs with the word "sonar". The old
+# `sonar.{0,50}…[0-9a-f]{40}` regex false-positived on all of these.
+# ok: detected-sonarqube-docs-api-key
+uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
+# ok: detected-sonarqube-docs-api-key
+uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b
+# ok: detected-sonarqube-docs-api-key
+image: sonarqube:community@sha256:160bd2f6a3485bd09b655ef22dd63c02bd1fa7ba82aa5d9973fd010b8bcca0b3
+# ok: detected-sonarqube-docs-api-key
+pkg:githubactions/SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e

--- a/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
+++ b/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
@@ -1,7 +1,15 @@
 rules:
 - id: detected-sonarqube-docs-api-key
+  # The 40-hex value must be ASSIGNED to a `sonar`-prefixed key (`=`/`:` after a
+  # sonar identifier), not merely co-occur within 50 chars of the word "sonar".
+  # The previous `sonar.{0,50}…[0-9a-f]{40}` bridged unrelated tokens — it fired
+  # on `SonarSource/…-action@<git-sha>` and `sonarqube@sha256:<digest>` because a
+  # 40-char commit SHA / image digest is indistinguishable from a token by length
+  # alone. Restricting the gap to identifier chars (no `/ @ :` bridging) and
+  # requiring an assignment keeps real `sonar…token = <hex>` detections while
+  # dropping the pin/digest false positives. (RE2-compatible: no lookarounds.)
   pattern-regex: |-
-    (?i)sonar.{0,50}(\\\"|'|`)?[0-9a-f]{40}(\\\"|'|`)?
+    (?i)sonar[a-z0-9_.-]{0,30}(token|key|login|password|pass|secret|auth)?\s*[:=]\s*(\\?["'`])?[0-9a-f]{40}\b
   languages: [regex]
   message: SonarQube Docs API Key detected
   severity: ERROR


### PR DESCRIPTION
## What

Tighten `generic.secrets.security.detected-sonarqube-docs-api-key` so it requires the 40-hex value to be **assigned** to a `sonar`-prefixed key, instead of merely **co-occurring** within 50 characters of the word "sonar".

## Why — false positives on SHA-pinned SonarSource Actions & image digests

The current pattern:

```
(?i)sonar.{0,50}(\\\"|'|`)?[0-9a-f]{40}(\\\"|'|`)?
```

The `.{0,50}` bridges unrelated tokens (it spans `/`, `@`, `:`), so any 40-char lowercase-hex string within 50 chars of "sonar" matches. A **git commit SHA** and an **image digest** are indistinguishable from a real token by length alone, so the rule fires on completely normal, non-secret CI config:

```yaml
uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b
image: sonarqube:community@sha256:160bd2f6a3485bd09b655ef22dd63c02bd1fa7ba82aa5d9973fd010b8bcca0b3
```

SHA-pinning SonarSource's own Actions (a widely-recommended supply-chain practice) *guarantees* this false positive. In one real repo it fired 17 times — every hit a public, required pin, none a credential.

## Fix

```
(?i)sonar[a-z0-9_.-]{0,30}(token|key|login|password|pass|secret|auth)?\s*[:=]\s*(\\?["'`])?[0-9a-f]{40}\b
```

- Restricts the gap after `sonar` to **identifier chars** (`[a-z0-9_.-]`), so it can't bridge across `/`, `@`, `:` into a path/pin/digest.
- Requires an **assignment** (`:` or `=`) before the value — the shape a real credential has (`sonar.token=…`, `SONAR_TOKEN: "…"`, `SONARQUBE=…`).
- RE2-compatible (no lookarounds), so it works in `generic`/`regex` mode.

## Tests

`detected-sonarqube-docs-api-key.txt` is extended (the original TP is kept):

- **4 true positives** (`# ruleid:`) — including the original `SONARQUBE=<hex>` plus `sonar.login=`, `sonar.token: "..."`, `SONAR_TOKEN = ...`.
- **4 false positives** (`# ok:`) — the two SonarSource Action SHA pins, the image digest, and a `pkg:githubactions/...` purl. These encode the regression: any future widening back toward `.{0,50}` will fail `semgrep --test`.

```
$ semgrep --test --config detected-sonarqube-docs-api-key.yaml detected-sonarqube-docs-api-key.txt
1/1: ✓ All tests passed
```

## Notes

- `confidence: LOW` is retained — this is a heuristic secret rule; the change narrows it toward the credential-assignment shape without adding new detections beyond what the key-name/assignment structure implies.
- No change to the `paths.exclude` list.
