### PR TITLE
fix: Solidity move basic-oracle-manipulation test annotation to the matched line

### DIFF
--- a/solidity/security/basic-oracle-manipulation.sol
+++ b/solidity/security/basic-oracle-manipulation.sol
@@ -97,9 +97,9 @@ contract OneRingVault is ERC20Upgradeable, OwnableUpgradeable {
         balance = IStrategy(activeStrategy).investedBalanceInUSD();
     }
     function getSharePrice() public view returns (uint256 _sharePrice) {
-        // ruleid: basic-oracle-manipulation
         _sharePrice = totalSupply() == 0
             ? underlyingUnit
+            // ruleid: basic-oracle-manipulation
             : underlyingUnit.mul(balanceWithInvested()).div(totalSupply());
 
         if (_sharePrice < underlyingUnit) {


### PR DESCRIPTION
Relates to the Solidity grammar update from https://github.com/semgrep/semgrep-proprietary/pull/6721 and others..

## Summary

The `basic-oracle-manipulation` test's `pattern: $X.div($Y)` match for `underlyingUnit.mul(balanceWithInvested()).div(totalSupply())` is textually on the `:` (else) branch line of a multi-line ternary, not the line where the enclosing assignment starts. The `// ruleid:` annotation was placed one line above the wrong branch.

Confirmed by parsing the snippet directly with tree-sitter-solidity v1.2.13 (via [semgrep/ocaml-tree-sitter-semgrep#626](https://github.com/semgrep/ocaml-tree-sitter-semgrep/pull/626)):

```
(ternary_expression
  (expression ...)                    ; condition: totalSupply() == 0
  (expression ...)                    ; then: underlyingUnit
  (expression (call_expression ...))) ; else: underlyingUnit.mul(...).div(...) -- entirely on its own line
```

The `.div(...)` call is entirely on the `:` branch's line — there's no way for a textually-accurate match to be reported one line earlier. This surfaced as a CI failure (1 false negative, 1 false positive) in [semgrep-proprietary#6721](https://github.com/semgrep/semgrep-proprietary/pull/6721), which bumps tree-sitter-solidity to v1.2.13 and produces a more precise AST for this multi-line ternary than whatever it replaced.

## Change

Moves the `// ruleid: basic-oracle-manipulation` annotation from immediately above the assignment to immediately above the actual matched (`:`) branch. No line count change, so no ripple to other annotations later in the file.

## Test plan
- [x] Verified via direct tree-sitter parse that the matched sub-expression's span is on the line the annotation now precedes.
- [ ] CI green on this PR (semgrep-core test suite should now pass `basic-oracle-manipulation.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)