### PR TITLE
chore: remove `workflow` from GHA shell injection rules

### DIFF
--- a/yaml/github-actions/security/github-script-injection.test.yaml
+++ b/yaml/github-actions/security/github-script-injection.test.yaml
@@ -149,6 +149,13 @@ jobs:
             const ref = "${{ github.event.deployment.ref }}";
             console.log(ref);
 
+      - name: Script with workflow name
+        uses: actions/github-script@v6
+        with:
+          # ok: github-script-injection
+          script: |
+            console.log("Workflow: ${{ github.workflow }}");
+
       - name: Ok script 1
         uses: not-github/custom-action@latest
         with:

--- a/yaml/github-actions/security/github-script-injection.yaml
+++ b/yaml/github-actions/security/github-script-injection.yaml
@@ -71,7 +71,6 @@ rules:
         - pattern: ${{ ... github.base_ref ... }}
         - pattern: ${{ ... github.head_ref ... }}
         - pattern: ${{ ... github.ref_name ... }}
-        - pattern: ${{ ... github.workflow ... }}
         - pattern: ${{ ... github.event.inputs ... }}
         - pattern: ${{ ... github.event.discussion.title ... }}
         - pattern: ${{ ... github.event.discussion.body ... }}
@@ -109,7 +108,6 @@ rules:
       - pattern-not: ${{ ... github.base_ref && ... }}
       - pattern-not: ${{ ... github.head_ref && ... }}
       - pattern-not: ${{ ... github.ref_name && ... }}
-      - pattern-not: ${{ ... github.workflow && ... }}
       - pattern-not: ${{ ... github.event.inputs && ... }}
       - pattern-not: ${{ ... github.event.discussion.title && ... }}
       - pattern-not: ${{ ... github.event.discussion.body && ... }}

--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -141,6 +141,10 @@ jobs:
         # ruleid: run-shell-injection
         run: |
           echo "Base branch: ${{ github.base_ref }}"
+      - name: Show workflow name
+        # ok: run-shell-injection
+        run: |
+          echo "Workflow: ${{ github.workflow }}"
       - name: Show ref name
         # ruleid: run-shell-injection
         run: |

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -59,7 +59,6 @@ rules:
         - pattern: ${{ ... github.base_ref ... }}
         - pattern: ${{ ... github.head_ref ... }}
         - pattern: ${{ ... github.ref_name ... }}
-        - pattern: ${{ ... github.workflow ... }}
         - pattern: ${{ ... github.event.inputs ... }}
         - pattern: ${{ ... github.event.discussion.title ... }}
         - pattern: ${{ ... github.event.discussion.body ... }}
@@ -98,7 +97,6 @@ rules:
       - pattern-not: ${{ ... github.base_ref && ... }}
       - pattern-not: ${{ ... github.head_ref && ... }}
       - pattern-not: ${{ ... github.ref_name && ... }}
-      - pattern-not: ${{ ... github.workflow && ... }}
       - pattern-not: ${{ ... github.event.inputs && ... }}
       - pattern-not: ${{ ... github.event.discussion.title && ... }}
       - pattern-not: ${{ ... github.event.discussion.body && ... }}


### PR DESCRIPTION
`workflow` is the name of the workflow and not attacker controlled