### PR TITLE
fix(terraform): allow AWS FIPS TLS policies in insecure-load-balancer-tls-version

### DIFF
--- a/terraform/aws/security/insecure-load-balancer-tls-version.tf
+++ b/terraform/aws/security/insecure-load-balancer-tls-version.tf
@@ -179,6 +179,48 @@ resource "aws_alb_listener" "tls_1_3_1_3" {
   }
 }
 
+resource "aws_alb_listener" "tls_1_2_fips" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls_1_2_res_fips" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-FIPS-2023-04"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls_1_2_fips_pq" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-PQ-2025-09"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
 resource "aws_lb_target_group" "foo" {
     name = "foo"
     port = 80
@@ -255,6 +297,34 @@ resource "aws_alb_listener" "tls_fs_1_0" {
   port              = "8080"
   # ruleid: insecure-load-balancer-tls-version
   ssl_policy        = "ELBSecurityPolicy-FS-2018-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls13_1_1_fips" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "HTTPS"
+  port              = "443"
+  # ruleid: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls13_1_0_pq" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "HTTPS"
+  port              = "443"
+  # ruleid: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-0-PQ-2025-09"
   certificate_arn   = var.certificate_arn
 
   default_action {

--- a/terraform/aws/security/insecure-load-balancer-tls-version.yaml
+++ b/terraform/aws/security/insecure-load-balancer-tls-version.yaml
@@ -7,6 +7,10 @@ rules:
       # See: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
       - pattern-not-regex: "ELBSecurityPolicy-TLS13-1-[23]-[(Res)0-9-]+"
       - pattern-not-regex: "ELBSecurityPolicy-FS-1-2-[(Res)0-9-]+"
+      # AWS FIPS policies (ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04 and the Res-FIPS
+      # and FIPS-PQ variants) keep the TLS 1.2/1.3 floor encoded by the version
+      # segment before the FIPS token, and add no static-RSA or SHA1-HMAC suites.
+      - pattern-not-regex: "ELBSecurityPolicy-TLS13-1-[23]-(Res-)?FIPS-"
     - patterns:
       - pattern: protocol = "HTTP"
       - pattern-not-inside: |


### PR DESCRIPTION
## Link to an issue, if relevant

No existing issue — the full analysis is inline below. Happy to file one separately if you prefer.

## Why this change

`terraform.aws.security.insecure-load-balancer-tls-version` false-positives on AWS's FIPS TLS policies:

```hcl
resource "aws_lb_listener" "this" {
  protocol   = "HTTPS"
  # flagged today, but this policy is TLS 1.2/1.3 only
  ssl_policy = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
  # ...
}
```

The allowlist matches policy-name suffixes with the character class `[(Res)0-9-]+` (the parentheses are literal characters inside a class), which only admits `R`/`e`/`s`/digits/hyphens. AWS's FIPS policy family ([2023-04](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html)) and the hybrid post-quantum `FIPS-PQ` variants (2025-09) put a `FIPS` token in the suffix — `F`/`I`/`P` fall outside the class, so the `pattern-not-regex` never matches and the rule fires on policies whose minimum protocol version is TLS 1.2.

## The fix

One added allowlist entry:

```yaml
- pattern-not-regex: "ELBSecurityPolicy-TLS13-1-[23]-(Res-)?FIPS-"
```

The version segment before the FIPS token is what encodes the protocol floor, so the genuinely insecure `ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04` / `-TLS13-1-0-FIPS-*` variants (min TLS 1.1/1.0) still fail the regex and remain flagged — pinned by two new `ruleid` test cases.

## This admits no weaker crypto than the existing allowlist

Verified against the live AWS API (`aws elbv2 describe-ssl-policies`) and the [ALB security policies docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html):

- Each of the four newly admitted policies (`TLS13-1-2-FIPS-2023-04`, `TLS13-1-2-FIPS-PQ-2025-09`, `TLS13-1-3-FIPS-2023-04`, `TLS13-1-3-FIPS-PQ-2025-09`) is a **strict cipher-subset of the already-allowlisted `ELBSecurityPolicy-TLS13-1-2-2021-06`** (AWS's default policy). The only cipher delta is a removal — ChaCha20-Poly1305, which is not FIPS-approved.
- Every suite uses ECDHE or TLS 1.3 key exchange (forward secrecy throughout) with SHA-2: no static-RSA, no SHA1-HMAC. The `1-3` policies raise the floor to TLS 1.3-only.
- The `PQ` variants add hybrid post-quantum key exchange (`X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`); hybrid retains full classical ECDHE security, and AWS recommends these policies.
- Per AWS: "All FIPS policies leverage the AWS-LC FIPS validated cryptographic module."

Deliberately **not** allowlisted: the `Ext0/1/2-FIPS` variants — the same API data shows they add SHA1-HMAC and/or static-RSA (non-forward-secret) suites — and the non-FIPS `PQ` policies, which are out of scope for this fix.

## Tests

- 3 new `ok` cases: `TLS13-1-2-FIPS-2023-04`, `TLS13-1-2-Res-FIPS-2023-04`, `TLS13-1-2-FIPS-PQ-2025-09`
- 2 new `ruleid` cases: `TLS13-1-1-FIPS-2023-04`, `TLS13-1-0-PQ-2025-09`
- `semgrep --validate` and `semgrep --test` pass locally (semgrep 1.169.0)