### PR TITLE
fix(gha): skip non-bash shells in curl nested-bash rules

### DIFF
--- a/yaml/github-actions/security/curl-eval.test.yaml
+++ b/yaml/github-actions/security/curl-eval.test.yaml
@@ -23,3 +23,18 @@ jobs:
         run: |
           CONTENTS=$(curl https://blah.com)
           eval $CONTENTS
+
+      - name: PowerShell step must not be bash-parsed
+        shell: pwsh
+        # ok: curl-eval
+        run: |
+          $cacheDirs = @("D:\cache")
+          foreach ($dir in $cacheDirs) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+          }
+      - name: explicit bash still detected
+        shell: bash
+        # ruleid: curl-eval
+        run: |
+          CONTENTS=$(curl https://blah.com)
+          eval $CONTENTS

--- a/yaml/github-actions/security/curl-eval.yaml
+++ b/yaml/github-actions/security/curl-eval.yaml
@@ -27,12 +27,38 @@ rules:
     likelihood: LOW
     impact: HIGH
     confidence: LOW
+  # Restrict bash nested parse to default-shell / bash / sh steps (issue #4001).
   patterns:
   - pattern-inside: 'steps: [...]'
-  - pattern-inside: |
-      - run: ...
-        ...
-  - pattern: 'run: $SHELL'
+  - pattern-either:
+    - patterns:
+      - pattern-inside: |
+          - run: ...
+            ...
+      - pattern-not-inside: |
+          - shell: ...
+            ...
+      - pattern: |
+          run: $SHELL
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            shell: bash
+            ...
+            run: $SHELL
+        - pattern: |
+            run: $SHELL
+            ...
+            shell: bash
+        - pattern: |
+            shell: sh
+            ...
+            run: $SHELL
+        - pattern: |
+            run: $SHELL
+            ...
+            shell: sh
+  - focus-metavariable: $SHELL
   - metavariable-pattern:
       language: bash
       metavariable: $SHELL
@@ -41,4 +67,5 @@ rules:
           $DATA=<... curl ...>
           ...
           eval <... $DATA ...>
+
   severity: ERROR

--- a/yaml/github-actions/security/gha-curl-pipe-shell.test.yaml
+++ b/yaml/github-actions/security/gha-curl-pipe-shell.test.yaml
@@ -57,3 +57,16 @@ jobs:
           curl -fsSL https://example.com/install.sh -o /tmp/install.sh
           sha256sum /tmp/install.sh
           bash /tmp/install.sh
+
+      - name: PowerShell step must not be bash-parsed
+        shell: pwsh
+        # ok: gha-curl-pipe-shell
+        run: |
+          $cacheDirs = @("D:\cache")
+          foreach ($dir in $cacheDirs) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+          }
+      - name: explicit bash curl pipe still detected
+        shell: bash
+        # ruleid: gha-curl-pipe-shell
+        run: curl -fsSL https://example.com/install.sh | bash

--- a/yaml/github-actions/security/gha-curl-pipe-shell.yaml
+++ b/yaml/github-actions/security/gha-curl-pipe-shell.yaml
@@ -28,12 +28,38 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: HIGH
+  # Restrict bash nested parse to default-shell / bash / sh steps (issue #4001).
   patterns:
   - pattern-inside: 'steps: [...]'
-  - pattern-inside: |
-      - run: ...
-        ...
-  - pattern: 'run: $SHELL'
+  - pattern-either:
+    - patterns:
+      - pattern-inside: |
+          - run: ...
+            ...
+      - pattern-not-inside: |
+          - shell: ...
+            ...
+      - pattern: |
+          run: $SHELL
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            shell: bash
+            ...
+            run: $SHELL
+        - pattern: |
+            run: $SHELL
+            ...
+            shell: bash
+        - pattern: |
+            shell: sh
+            ...
+            run: $SHELL
+        - pattern: |
+            run: $SHELL
+            ...
+            shell: sh
+  - focus-metavariable: $SHELL
   - metavariable-pattern:
       language: bash
       metavariable: $SHELL
@@ -44,4 +70,5 @@ rules:
       - metavariable-regex:
           metavariable: $CMD
           regex: '^(bash|sh|python3?|ruby|perl)$'
+
   severity: ERROR


### PR DESCRIPTION
## Summary
Fixes #4001 for `curl-eval` and `gha-curl-pipe-shell`.

Those rules always nested-parse every `run:` body as Bash. Explicit `shell: pwsh` / PowerShell steps then raise `PartialParsing` under `--strict` and can exit non-zero even when the step is not Bash.

## Change
- Only feed `language: bash` metavariable-pattern for default-shell steps (no `shell:` key) or explicit `shell: bash` / `shell: sh`
- Use `focus-metavariable: $SHELL` so findings stay on the script body
- Tests: PowerShell `# ok` repro from the issue + explicit bash `# ruleid` controls

## Test plan
- [x] `semgrep test yaml/github-actions/security` (12/12)
- [x] Issue-style `shell: pwsh` workflow under `--strict` against both rules: 0 findings, no PartialParsing

Closes #4001
