### PR TITLE
Fix uv cooldown rule with brackets in TOML sections

### DIFF
--- a/package_managers/uv/uv-missing-dependency-cooldown.test.toml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.test.toml
@@ -32,6 +32,18 @@ exclude-newer = "7 days"
 [tool.uv]
 constraint-dependencies = ["grpcio<1.65"]
 
+# ruleid: uv-missing-dependency-cooldown
+[tool.uv]
+override-dependencies = ["urllib3<2"]
+# TODO [security]: configure exclude-newer after rollout
+
+# ok: uv-missing-dependency-cooldown
+[tool.uv]
+constraint-dependencies = [
+  ["nested"],
+]
+exclude-newer = "7 days"
+
 [tool.uv]
 # ruleid: uv-missing-dependency-cooldown
 exclude-newer = "3 days"

--- a/package_managers/uv/uv-missing-dependency-cooldown.test.toml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.test.toml
@@ -18,6 +18,20 @@ dev-dependencies = ["pytest"]
 [tool.uv]
 exclude-newer = "7 days"
 
+# ok: uv-missing-dependency-cooldown
+[tool.uv]
+constraint-dependencies = ["grpcio<1.65"]
+exclude-newer = "7 days"
+
+# ok: uv-missing-dependency-cooldown
+[tool.uv]
+# A comment containing [square brackets] is not a TOML table header.
+exclude-newer = "7 days"
+
+# ruleid: uv-missing-dependency-cooldown
+[tool.uv]
+constraint-dependencies = ["grpcio<1.65"]
+
 [tool.uv]
 # ruleid: uv-missing-dependency-cooldown
 exclude-newer = "3 days"

--- a/package_managers/uv/uv-missing-dependency-cooldown.yaml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.yaml
@@ -4,7 +4,7 @@ rules:
     pattern-either:
       # Branch 1a: pyproject.toml missing exclude-newer in [tool.uv]
       - patterns:
-          - pattern-regex: '(?ms)\[tool\.uv\](?P<TARGET>[^\[]*?)(?=\[|\z)'
+          - pattern-regex: '(?ms)^\s*\[tool\.uv\](?P<TARGET>.*?)(?=^\s*\[|\z)'
           - metavariable-regex:
               metavariable: $TARGET
               regex: '^(?![\s\S]*exclude-newer)'

--- a/package_managers/uv/uv-missing-dependency-cooldown.yaml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.yaml
@@ -4,10 +4,10 @@ rules:
     pattern-either:
       # Branch 1a: pyproject.toml missing exclude-newer in [tool.uv]
       - patterns:
-          - pattern-regex: '(?ms)^\s*\[tool\.uv\](?P<TARGET>.*?)(?=^\s*\[|\z)'
+          - pattern-regex: '(?ms)^\[tool\.uv\](?P<TARGET>.*?)(?=^\[|\z)'
           - metavariable-regex:
               metavariable: $TARGET
-              regex: '^(?![\s\S]*exclude-newer)'
+              regex: '(?m)^(?![\s\S]*^[ \t]*exclude-newer[ \t]*=)'
           - focus-metavariable: $TARGET
 
       # Branch 2: Value too low (< 7 days)


### PR DESCRIPTION
## Summary

- stop treating every `[` inside `[tool.uv]` as the beginning of a new TOML table
- recognize only table headers that begin a line when delimiting the section
- add regression coverage for inline arrays, comments containing brackets, and a missing cooldown after an array

## Root cause

The section matcher used `[^\[]*`, so ordinary TOML values and comments containing square brackets truncated `$TARGET`. As a result, a valid `exclude-newer` later in the same section was invisible to the rule.

## Validation

- `semgrep test package_managers/uv` (`1/1: All tests passed`)
- `semgrep validate package_managers/uv/uv-missing-dependency-cooldown.yaml`
- strict `metadata-cwe-prohibited-or-discouraged` lint on the changed rule (0 findings)

Fixes #3993.