### PR TITLE
fix: resolve false negative in asyncpg-sqli rule by migrating to taint mode

### DIFF
--- a/python/lang/security/audit/sqli/asyncpg-sqli.py
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.py
@@ -130,3 +130,10 @@ def ok11(user_input):
     # ok: asyncpg-sqli
     stmt = await con.prepare('SELECT ($1::int, $2::text)')
     print(stmt.get_parameters())
+
+async def bad12(conn: asyncpg.Connection, user_input: str):
+    sql_query = 'SELECT * FROM {}'.format(user_input)
+    sql_query_copy = sql_query
+    # ruleid: asyncpg-sqli
+    cur = await conn.cursor(sql_query_copy)
+

--- a/python/lang/security/audit/sqli/asyncpg-sqli.yaml
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.yaml
@@ -31,66 +31,42 @@ rules:
     likelihood: LOW
     impact: HIGH
     confidence: LOW
-  patterns:
-  - pattern-either:
-    - patterns:
-      - pattern: $CONN.$METHOD(...,$QUERY,...)
-      - pattern-either:
-        - pattern-inside: |
-            $QUERY = $X + $Y
-            ...
-        - pattern-inside: |
-            $QUERY += $X
-            ...
-        - pattern-inside: |
-            $QUERY = '...'.format(...)
-            ...
-        - pattern-inside: |
-            $QUERY = '...' % (...)
-            ...
-        - pattern-inside: |
-            $QUERY = f'...{$USERINPUT}...'
-            ...
-      - pattern-not-inside: |
-          $QUERY += "..."
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: $X + $Y
+      - pattern: $X += $Y
+      - pattern: $Y.format(...)
+      - pattern: '"..." % $ANYTHING'
+      - pattern: f"...{$ANYTHING}..."
+    - pattern-not: '"..." + "..."'
+    - pattern-not: $X += "..."
+    - pattern-not: '"...".format()'
+    - pattern-not: '"..." % ()'
+  pattern-sinks:
+  - patterns:
+    - pattern: $CONN.$METHOD(..., $QUERY, ...)
+    - pattern-either:
+      - pattern-inside: |
+          $CONN = await asyncpg.connect(...)
           ...
-      - pattern-not-inside: |
-          $QUERY = "..." + "..."
+      - pattern-inside: |
+          async with asyncpg.create_pool(...) as $CONN:
+              ...
+      - pattern-inside: |
+          async with $POOL.acquire(...) as $CONN:
+              ...
+      - pattern-inside: |
+          $CONN = await $POOL.acquire(...)
           ...
-      - pattern-not-inside: |
-          $QUERY = '...'.format()
-          ...
-      - pattern-not-inside: |
-          $QUERY = '...' % ()
-          ...
-    - pattern: $CONN.$METHOD(..., $X + $Y, ...)
-    - pattern: $CONN.$METHOD(..., $Y.format(...), ...)
-    - pattern: $CONN.$METHOD(..., '...'.format(...), ...)
-    - pattern: $CONN.$METHOD(..., '...' % (...), ...)
-    - pattern: $CONN.$METHOD(..., f'...{$USERINPUT}...', ...)
-  - pattern-either:
-    - pattern-inside: |
-        $CONN = await asyncpg.connect(...)
-        ...
-    - pattern-inside: |
-        async with asyncpg.create_pool(...) as $CONN:
-            ...
-    - pattern-inside: |
-        async with $POOL.acquire(...) as $CONN:
-            ...
-    - pattern-inside: |
-        $CONN = await $POOL.acquire(...)
-        ...
-    - pattern-inside: |
-        def $FUNCNAME(..., $CONN: Connection, ...):
-            ...
-    - pattern-inside: |
-        def $FUNCNAME(..., $CONN: asyncpg.Connection, ...):
-            ...
-  - pattern-not: $CONN.$METHOD(..., "..." + "...", ...)
-  - pattern-not: $CONN.$METHOD(..., '...'.format(), ...)
-  - pattern-not: $CONN.$METHOD(..., '...'%(), ...)
-  - metavariable-regex:
-      metavariable: $METHOD
-      regex: ^(fetch|fetchrow|fetchval|execute|executemany|prepare|cursor|copyfromquery)$
+      - pattern-inside: |
+          def $FUNCNAME(..., $CONN: Connection, ...):
+              ...
+      - pattern-inside: |
+          def $FUNCNAME(..., $CONN: asyncpg.Connection, ...):
+              ...
+    - metavariable-regex:
+        metavariable: $METHOD
+        regex: ^(fetch|fetchrow|fetchval|execute|executemany|prepare|cursor|copyfromquery)$
   severity: WARNING


### PR DESCRIPTION
## Summary
Fixes #3027 - the `asyncpg-sqli` rule missed SQL injection when the tainted query was reassigned to another variable before reaching the sink.

## Root Cause
The rule used AST `pattern-inside` matching, which requires the exact tainted variable name to appear in the sink call. When an intermediate assignment like `sql_query_copy = sql_query` was introduced, the rule lost track.

## Fix
Migrated the rule to `mode: taint`, which enables Semgrep's built-in data-flow analysis to automatically track taint through variable assignments.

- **Sources**: String concatenation (`+`), `+=`, `.format()`, `%` formatting, f-strings
- **Sinks**: asyncpg methods (`fetch`, `execute`, `cursor`, etc.) on connection objects
- All false-positive exclusions preserved (literal-only concatenation, empty `.format()`, empty `%`)

## Changes
- `python/lang/security/audit/sqli/asyncpg-sqli.yaml` - migrated to taint mode
- `python/lang/security/audit/sqli/asyncpg-sqli.py` - added `bad12` test case from #3027

## Testing
All existing tests pass (`semgrep --test`). The new `bad12` case is now correctly detected.