### PR TITLE
fix(java/jdo-sqli): detect String.formatted() as a tainted query source

### DIFF
--- a/java/lang/security/audit/sqli/jdo-sqli.java
+++ b/java/lang/security/audit/sqli/jdo-sqli.java
@@ -23,6 +23,13 @@ public class JdoSqlFilter {
         q.setFilter("id == "+filterValue);
     }
 
+    public void testJdoUnsafeFilterFormatted(String filterValue) {
+        PersistenceManager pm = getPM();
+        Query q = pm.newQuery(UserEntity.class);
+        // ruleid: jdo-sqli
+        q.setFilter("id == %s".formatted(filterValue));
+    }
+
     public void testJdoSafeFilter(String filterValue) {
         PersistenceManager pm = getPM();
         Query q = pm.newQuery(UserEntity.class);
@@ -87,10 +94,14 @@ public class JdoSql {
         PersistenceManager pm = getPM();
         // ruleid: jdo-sqli
         pm.newQuery(UserEntity.class,new ArrayList(),"id == "+ input);
+        // ruleid: jdo-sqli
+        pm.newQuery(UserEntity.class,new ArrayList(),"id == %s".formatted(input));
         // ok: jdo-sqli
         pm.newQuery(UserEntity.class,new ArrayList(),"id == 1");
         // ruleid: jdo-sqli
         pm.newQuery(UserEntity.class,"id == "+ input);
+        // ruleid: jdo-sqli
+        pm.newQuery(UserEntity.class,"id == %s".formatted(input));
         // ok: jdo-sqli
         pm.newQuery(UserEntity.class,"id == 1");
         // ruleid: jdo-sqli

--- a/java/lang/security/audit/sqli/jdo-sqli.yaml
+++ b/java/lang/security/audit/sqli/jdo-sqli.yaml
@@ -12,6 +12,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = "...".formatted(...);
+              ...
+          - pattern-inside: |
               $TYPE $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -21,6 +24,8 @@ rules:
         - pattern: $Q.$METHOD($SQL,...)
       - pattern: |
           $Q.$METHOD(String.format(...),...);
+      - pattern: |
+          $Q.$METHOD("...".formatted(...),...);
       - pattern: |
           $Q.$METHOD($X + $Y,...);
     - pattern-either:
@@ -47,6 +52,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = "...".formatted(...);
+              ...
+          - pattern-inside: |
               $VAL $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -56,6 +64,8 @@ rules:
         - pattern: $PM.newQuery(...,$SQL,...)
       - pattern: |
           $PM.newQuery(...,String.format(...),...);
+      - pattern: |
+          $PM.newQuery(...,"...".formatted(...),...);
       - pattern: |
           $PM.newQuery(...,$X + $Y,...);
     - pattern-either:


### PR DESCRIPTION
Closes #3812.

## Problem

`java/lang/security/audit/sqli/jdo-sqli` flags a formatted/concatenated string passed to JDO query APIs (`setFilter`/`setGrouping`/`newQuery`). It already handles `String.format(...)` and `$X + $Y` concatenation, but **misses the Java 15+ instance method** `"...".formatted(input)`, which produces the exact same attacker-controlled query string:

```java
q.setFilter("id == %s".formatted(filterValue));               // was NOT flagged
pm.newQuery(UserEntity.class, "id == %s".formatted(input));   // was NOT flagged
```

Reproduction scanned with **0 findings** before this change — a SQL-injection false negative.

## Fix

Mirror the existing `String.format(...)` handling with `"...".formatted(...)` patterns, in both the `Query` and `PersistenceManager` branches — as a `pattern-inside` source (`String $SQL = "...".formatted(...);`) and as a direct argument (`$Q.$METHOD("...".formatted(...),...)` / `$PM.newQuery(...,"...".formatted(...),...)`).

Added `// ruleid:` test cases for the new patterns. `semgrep --test` reports **All tests passed** (existing `// ok:` cases still don't match).