### PR TITLE
ci: inline SHA-pinned pre-commit (fix broken reusable-workflow call) [SEC-2479]

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: .pre-commit-config.yaml
-          version: "0.11.15"
+          version: "0.11.x"
       - name: Cache pre-commit hook envs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,8 +5,31 @@ on:
   push:
     branches: [master, develop]
 
+# Inlined (rather than calling the shared reusable workflow) because this is a
+# public repo, and public repos can't call reusable workflows in the internal
+# semgrep/release-workflows repo. Actions are SHA-pinned to match.
 jobs:
   pre-commit:
-    uses: semgrep/release-workflows/.github/workflows/pre-commit.yaml@c04907222197635bc8fc0d80b1d5fec8f945eb43 # develop
-    with:
-      skip: yamlfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Honor .python-version
+        if: hashFiles('.python-version') != ''
+        run: echo "UV_PYTHON=$(cat .python-version)" >> "$GITHUB_ENV"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: .pre-commit-config.yaml
+          version: "0.11.15"
+      - name: Cache pre-commit hook envs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-v1|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: uv tool install pre-commit --with pre-commit-uv
+      - name: Run pre-commit
+        env:
+          SKIP: yamlfmt
+        run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-v1|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pre-commit
-        run: uv tool install pre-commit --with pre-commit-uv
+        run: UV_EXCLUDE_NEWER="1 week" uv tool install pre-commit --with pre-commit-uv
       - name: Run pre-commit
         env:
           SKIP: yamlfmt

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [master, develop]
 
-# Inlined (rather than calling the shared reusable workflow) because this is a
-# public repo, and public repos can't call reusable workflows in the internal
-# semgrep/release-workflows repo. Actions are SHA-pinned to match.
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Can't point to a private reusable workflow