### PR TITLE
fix(gha): run-shell-injection flags the truthiness-check shape on bare inputs

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -133,6 +133,10 @@ jobs:
         # ruleid: run-shell-injection
         run: |
           echo "${{ inputs.message_to_print }}"
+      - name: truthiness check on input, not interpolated
+        # ok: run-shell-injection
+        run: |
+          echo "${{ inputs.message_to_print && 'yes' }}"
       - name: Use steps output
         # ok: run-shell-injection
         run: |

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -109,4 +109,5 @@ rules:
       - pattern-not: ${{ ... github.event.release.name && ... }}
       - pattern-not: ${{ ... github.event.release.body && ... }}
       - pattern-not: ${{ ... github.event.deployment.ref && ... }}
+      - pattern-not: ${{ ... inputs ... && ... }}
   severity: ERROR


### PR DESCRIPTION
The `run-shell-injection` rule exempts the truthiness-check shape `${{ X && 'literal' }}` from every dangerous source, since `X` is only evaluated for truthiness and never interpolated into the shell. There are 35 sources in the `pattern-either` list and 34 matching `pattern-not` exemptions. The one source that never got its exemption is `inputs`.

So `${{ inputs.foo && 'yes' }}` still gets flagged, even though it's the exact same safe shape as `${{ github.head_ref && 'yes' }}` a few lines up, which is correctly exempted.

Added the missing `pattern-not: ${{ ... inputs ... && ... }}` so `inputs` matches the other 34, and an `ok:` test case for it. A bare `${{ inputs.foo }}` interpolation still fires, so this only drops the false positive on the truthiness shape, not any real detection.

## Verification

I checked the rule structure directly: the `pattern-either` list has 35 sources, the truthiness `pattern-not` list has 34, and `inputs` is the only source with no matching entry. The added pattern mirrors the existing siblings exactly (`${{ ... <source> ... && ... }}`).

Added a paired `ok:` case in `run-shell-injection.test.yaml` (`echo "${{ inputs.message_to_print && 'yes' }}"`), alongside the existing `ruleid:` case for the bare interpolation, which stays flagged.
