### PR TITLE
fix(c): describe the real hazard in insecure-use-strtok-fn

### DIFF
--- a/c/lang/security/insecure-use-strtok-fn.yaml
+++ b/c/lang/security/insecure-use-strtok-fn.yaml
@@ -2,9 +2,12 @@ rules:
 - id: insecure-use-strtok-fn
   pattern: strtok(...)
   message: >-
-    Avoid using 'strtok()'. This function directly modifies the first argument buffer,
-    permanently erasing the
-    delimiter character. Use 'strtok_r()' instead.
+    Avoid 'strtok()': it is not reentrant or thread-safe, since it keeps the parser
+    position in a hidden static buffer, so interleaved or concurrent calls (even on
+    unrelated strings) clobber each other's state. It also modifies its input in
+    place, overwriting each delimiter with a NUL byte. Use the reentrant
+    'strtok_r()' (POSIX) or 'strtok_s()' (C11 Annex K), which keep the scan state in
+    a caller-provided context.
   metadata:
     cwe:
     - 'CWE-676: Use of Potentially Dangerous Function'

--- a/c/lang/security/insecure-use-strtok-fn.yaml
+++ b/c/lang/security/insecure-use-strtok-fn.yaml
@@ -2,12 +2,12 @@ rules:
 - id: insecure-use-strtok-fn
   pattern: strtok(...)
   message: >-
-    Avoid 'strtok()': it is not reentrant or thread-safe, since it keeps the parser
-    position in a hidden static buffer, so interleaved or concurrent calls (even on
-    unrelated strings) clobber each other's state. It also modifies its input in
-    place, overwriting each delimiter with a NUL byte. Use the reentrant
-    'strtok_r()' (POSIX) or 'strtok_s()' (C11 Annex K), which keep the scan state in
-    a caller-provided context.
+    Avoid 'strtok()': it is not reentrant, and the C standard does not require it to
+    be thread-safe. It keeps the scan position in hidden static state, so interleaved
+    calls (even on unrelated strings) clobber each other. It also modifies its input
+    in place, replacing each token-ending delimiter with a NUL byte. Use the
+    reentrant 'strtok_r()' (POSIX) or 'strtok_s()' (C11 Annex K), which keep the scan
+    state in a caller-provided context.
   metadata:
     cwe:
     - 'CWE-676: Use of Potentially Dangerous Function'


### PR DESCRIPTION
Fixes #3772

## Problem

The `insecure-use-strtok-fn` message describes `strtok()`'s documented behavior as if it were the hazard:

> Avoid using 'strtok()'. This function directly modifies the first argument buffer, permanently erasing the delimiter character. Use 'strtok_r()' instead.

Modifying the input in place is exactly what `strtok()` is specified to do, and it is not why the rule recommends `strtok_r()`. As #3772 points out, the message leaves a reader unsure what the actual risk is — and it doesn't explain what makes the suggested replacement better, since `strtok_r()` modifies the buffer in the same way.

## Change

Message only — the pattern, metadata and severity are untouched.

The rewrite leads with the real reason `strtok_r()` exists: `strtok()` keeps the parser position in a hidden static buffer, so it is neither reentrant nor thread-safe and interleaved or concurrent calls clobber each other's state. In-place modification is kept as a secondary note, and `strtok_s()` (C11 Annex K) is mentioned next to `strtok_r()` for portability.

No test changes are needed since matching behavior is unchanged.
