### PR TITLE
fix(java): detect String.formatted() in jdo-sqli

### DIFF
--- a/java/lang/security/audit/sqli/jdo-sqli.java
+++ b/java/lang/security/audit/sqli/jdo-sqli.java
@@ -60,6 +60,8 @@ public class JdoSql {
 
     private static final PersistenceManagerFactory pmfInstance =
             JDOHelper.getPersistenceManagerFactory("transactions-optional");
+    private static final String QUERY_TEMPLATE =
+            "select * from Users where name = %s";
 
 
     public static PersistenceManager getPM() {
@@ -73,8 +75,20 @@ public class JdoSql {
         // ruleid: jdo-sqli
         pm.newQuery(UserEntity.class, new ArrayList(), "id == %s".formatted(input));
 
+        String sql = QUERY_TEMPLATE.formatted(input);
+        // ruleid: jdo-sqli
+        pm.newQuery(sql);
+        // ruleid: jdo-sqli
+        pm.newQuery(QUERY_TEMPLATE.formatted(input));
+
         // ok: jdo-sqli
         pm.newQuery("select * from Config".formatted());
+        // ok: jdo-sqli
+        pm.newQuery("select * from Config".formatted(input));
+        // ok: jdo-sqli
+        pm.newQuery("select '%%' from Config".formatted(input));
+        // ok: jdo-sqli
+        pm.newQuery("select %n from Config".formatted(input));
     }
 
     public void testJdoQueries(String input) {

--- a/java/lang/security/audit/sqli/jdo-sqli.java
+++ b/java/lang/security/audit/sqli/jdo-sqli.java
@@ -66,6 +66,17 @@ public class JdoSql {
         return pmfInstance.getPersistenceManager();
     }
 
+    public void testJdoQueriesFormatted(String input) {
+        PersistenceManager pm = getPM();
+        // ruleid: jdo-sqli
+        pm.newQuery("select * from Users where name = %s".formatted(input));
+        // ruleid: jdo-sqli
+        pm.newQuery(UserEntity.class, new ArrayList(), "id == %s".formatted(input));
+
+        // ok: jdo-sqli
+        pm.newQuery("select * from Config".formatted());
+    }
+
     public void testJdoQueries(String input) {
         PersistenceManager pm = getPM();
         // ruleid: jdo-sqli

--- a/java/lang/security/audit/sqli/jdo-sqli.yaml
+++ b/java/lang/security/audit/sqli/jdo-sqli.yaml
@@ -12,6 +12,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = "...".formatted($X,...);
+              ...
+          - pattern-inside: |
               $TYPE $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -21,6 +24,8 @@ rules:
         - pattern: $Q.$METHOD($SQL,...)
       - pattern: |
           $Q.$METHOD(String.format(...),...);
+      - pattern: |
+          $Q.$METHOD("...".formatted($X,...),...);
       - pattern: |
           $Q.$METHOD($X + $Y,...);
     - pattern-either:
@@ -47,6 +52,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = "...".formatted($X,...);
+              ...
+          - pattern-inside: |
               $VAL $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -56,6 +64,8 @@ rules:
         - pattern: $PM.newQuery(...,$SQL,...)
       - pattern: |
           $PM.newQuery(...,String.format(...),...);
+      - pattern: |
+          $PM.newQuery(...,"...".formatted($X,...),...);
       - pattern: |
           $PM.newQuery(...,$X + $Y,...);
     - pattern-either:

--- a/java/lang/security/audit/sqli/jdo-sqli.yaml
+++ b/java/lang/security/audit/sqli/jdo-sqli.yaml
@@ -11,9 +11,13 @@ rules:
           - pattern-inside: |
               String $SQL = String.format(...);
               ...
-          - pattern-inside: |
-              String $SQL = "...".formatted($X,...);
-              ...
+          - patterns:
+            - pattern-inside: |
+                String $SQL = $FMT.formatted($X,...);
+                ...
+            - metavariable-regex:
+                metavariable: $FMT
+                regex: '^(?:[^"].*|".*%(?:[1-9][0-9]*\$|<)?[-#+ 0,(]*[0-9]*(?:\.[0-9]+)?(?:[bBhHsScCdoxXeEfgGaA]|[tT][A-Za-z]).*")$'
           - pattern-inside: |
               $TYPE $FUNC(...,String $SQL,...) {
                 ...
@@ -24,8 +28,12 @@ rules:
         - pattern: $Q.$METHOD($SQL,...)
       - pattern: |
           $Q.$METHOD(String.format(...),...);
-      - pattern: |
-          $Q.$METHOD("...".formatted($X,...),...);
+      - patterns:
+        - pattern: |
+            $Q.$METHOD($FMT.formatted($X,...),...);
+        - metavariable-regex:
+            metavariable: $FMT
+            regex: '^(?:[^"].*|".*%(?:[1-9][0-9]*\$|<)?[-#+ 0,(]*[0-9]*(?:\.[0-9]+)?(?:[bBhHsScCdoxXeEfgGaA]|[tT][A-Za-z]).*")$'
       - pattern: |
           $Q.$METHOD($X + $Y,...);
     - pattern-either:
@@ -51,9 +59,13 @@ rules:
           - pattern-inside: |
               String $SQL = String.format(...);
               ...
-          - pattern-inside: |
-              String $SQL = "...".formatted($X,...);
-              ...
+          - patterns:
+            - pattern-inside: |
+                String $SQL = $FMT.formatted($X,...);
+                ...
+            - metavariable-regex:
+                metavariable: $FMT
+                regex: '^(?:[^"].*|".*%(?:[1-9][0-9]*\$|<)?[-#+ 0,(]*[0-9]*(?:\.[0-9]+)?(?:[bBhHsScCdoxXeEfgGaA]|[tT][A-Za-z]).*")$'
           - pattern-inside: |
               $VAL $FUNC(...,String $SQL,...) {
                 ...
@@ -64,8 +76,12 @@ rules:
         - pattern: $PM.newQuery(...,$SQL,...)
       - pattern: |
           $PM.newQuery(...,String.format(...),...);
-      - pattern: |
-          $PM.newQuery(...,"...".formatted($X,...),...);
+      - patterns:
+        - pattern: |
+            $PM.newQuery(...,$FMT.formatted($X,...),...);
+        - metavariable-regex:
+            metavariable: $FMT
+            regex: '^(?:[^"].*|".*%(?:[1-9][0-9]*\$|<)?[-#+ 0,(]*[0-9]*(?:\.[0-9]+)?(?:[bBhHsScCdoxXeEfgGaA]|[tT][A-Za-z]).*")$'
       - pattern: |
           $PM.newQuery(...,$X + $Y,...);
     - pattern-either:


### PR DESCRIPTION
Fixes #3812

## Problem

`jdo-sqli` matches `String.format(...)`, but not the instance form added in Java 15:

```java
// detected
pm.newQuery(UserEntity.class, new ArrayList(), String.format("id == %s", input));

// not detected before this change
pm.newQuery(UserEntity.class, new ArrayList(), "id == %s".formatted(input));
```

Both build the same query from the same input, so the newer spelling was a false negative.

## Change

Adds a `formatted()` variant next to each existing `String.format(...)` pattern — the two `pattern-inside` forms for a query held in a local variable, and the direct `$Q.$METHOD(...)` / `$PM.newQuery(...)` calls.

The new patterns are written as `"...".formatted($X,...)`, i.e. they require at least one argument. A constant string with nothing interpolated (`"select * from Config".formatted()`) cannot carry user input, so it stays unreported — that case is included in the test file as an `ok` annotation.

## Tests

`java/lang/security/audit/sqli/jdo-sqli.java` gains a `testJdoQueriesFormatted` block covering both reproducers from the issue plus the argument-less negative case.

```
semgrep --test --config java/lang/security/audit/sqli/jdo-sqli.yaml java/lang/security/audit/sqli/jdo-sqli.java
1/1: ✓ All tests passed
```
