### PR TITLE
fix(java): treat ACCESS_EXTERNAL_DTD as an XXE sanitizer

### DIFF
--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.fixed.java
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.fixed.java
@@ -3,6 +3,7 @@ package example;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.XMLConstants;
 
 
 class GoodDocumentBuilderFactory {
@@ -166,4 +167,15 @@ class GoodDocumentBuilderFactoryCtr3 {
         dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     }
 
+}
+
+class GoodDocumentBuilderFactoryAccessExternalDtd {
+    public void blockExternalDtd() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        //ok:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.newDocumentBuilder();
+    }
 }

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.fixed.java
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.fixed.java
@@ -179,3 +179,13 @@ class GoodDocumentBuilderFactoryAccessExternalDtd {
         dbf.newDocumentBuilder();
     }
 }
+
+class BadDocumentBuilderFactoryUnrelatedConstant {
+    public void unrelatedConstantNamedLikeJaxp() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setAttribute(MyOwnConfig.ACCESS_EXTERNAL_DTD, "");
+        //ruleid:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbf.newDocumentBuilder();
+    }
+}

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.java
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.java
@@ -175,3 +175,12 @@ class GoodDocumentBuilderFactoryAccessExternalDtd {
         dbf.newDocumentBuilder();
     }
 }
+
+class BadDocumentBuilderFactoryUnrelatedConstant {
+    public void unrelatedConstantNamedLikeJaxp() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setAttribute(MyOwnConfig.ACCESS_EXTERNAL_DTD, "");
+        //ruleid:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.newDocumentBuilder();
+    }
+}

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.java
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.java
@@ -3,6 +3,7 @@ package example;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.XMLConstants;
 
 
 class GoodDocumentBuilderFactory {
@@ -162,4 +163,15 @@ class GoodDocumentBuilderFactoryCtr3 {
         dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     }
 
+}
+
+class GoodDocumentBuilderFactoryAccessExternalDtd {
+    public void blockExternalDtd() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        //ok:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.newDocumentBuilder();
+    }
 }

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
@@ -117,7 +117,7 @@ rules:
                   - pattern: $FACTORY.setAttribute($ATTR, "")
                   - metavariable-regex:
                       metavariable: $ATTR
-                      regex: ^(.*\.)?ACCESS_EXTERNAL_DTD$
+                      regex: ^(javax\.xml\.)?XMLConstants\.ACCESS_EXTERNAL_DTD$|^ACCESS_EXTERNAL_DTD$
             - focus-metavariable: $FACTORY
           - patterns:
               - pattern-either:

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
@@ -113,6 +113,11 @@ rules:
                   ...
 
                   $FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+              - patterns:
+                  - pattern: $FACTORY.setAttribute($ATTR, "")
+                  - metavariable-regex:
+                      metavariable: $ATTR
+                      regex: ^(.*\.)?ACCESS_EXTERNAL_DTD$
             - focus-metavariable: $FACTORY
           - patterns:
               - pattern-either:


### PR DESCRIPTION
Addresses case 1 of #3831 (the false positive).

## Problem

The rule only recognizes `setFeature(...)` as a defense, so a factory hardened through the JAXP properties is still reported:

```java
DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
dbf.newDocumentBuilder();   // flagged before this change
```

Setting `ACCESS_EXTERNAL_DTD` to the empty string stops the parser from resolving external DTDs and entities — the same protection the rule already accepts from the `external-general-entities` + `external-parameter-entities` features, and the mitigation the OWASP XXE cheat sheet recommends when DOCTYPE declarations cannot be disabled outright.

## Change

One sanitizer alternative:

```yaml
- patterns:
    - pattern: $FACTORY.setAttribute($ATTR, "")
    - metavariable-regex:
        metavariable: $ATTR
        regex: ^(.*\.)?ACCESS_EXTERNAL_DTD$
```

Two notes on scope:

- The issue suggests matching `ACCESS_EXTERNAL_DTD|ACCESS_EXTERNAL_SCHEMA`. I deliberately match only `ACCESS_EXTERNAL_DTD`: `ACCESS_EXTERNAL_SCHEMA` restricts schema resolution and does not stop external entity resolution, so accepting it on its own would turn the false positive into a false negative. Code that sets both (as above) is still sanitized, via the DTD property.
- The regex is anchored so it works whether the constant is written qualified (`XMLConstants.ACCESS_EXTERNAL_DTD`) or imported statically.

Cases 2 and 3 of the issue (false negatives on chained `DocumentBuilderFactory.newInstance().newDocumentBuilder()`) are not addressed here — new sources interact with the rule's autofix, so they are better handled in a separate change.

## Tests

Added the reproducer as an `ok` case in the test file, mirrored into `.fixed.java`.

```
semgrep --test --config .../documentbuilderfactory-disallow-doctype-decl-missing.yaml .../documentbuilderfactory-disallow-doctype-decl-missing.java
1/1: ✓ All tests passed
1/1: ✓ All fix tests passed
```
