### PR TITLE
fix(django): let django-no-csrf-token span realistic form bodies

### DIFF
--- a/python/django/security/django-no-csrf-token.html
+++ b/python/django/security/django-no-csrf-token.html
@@ -10,6 +10,34 @@
   </div>
 </div>
 
+<!-- a token in a following sibling form must not suppress this finding -->
+<div class="container">
+<!-- ruleid: django-no-csrf-token -->
+  <form method="post">
+      <input type="text" name="unprotected">
+      <button type="submit">Submit</button>
+  </form>
+  <form method="post">
+      {% csrf_token %}
+      <input type="text" name="protected">
+      <button type="submit">Submit</button>
+  </form>
+</div>
+
+<!-- a token in a preceding sibling form must not suppress this finding -->
+<div class="container">
+  <form method="post">
+      {% csrf_token %}
+      <input type="text" name="protected">
+      <button type="submit">Submit</button>
+  </form>
+<!-- ruleid: django-no-csrf-token -->
+  <form method="post">
+      <input type="text" name="unprotected">
+      <button type="submit">Submit</button>
+  </form>
+</div>
+
 <div class="container">
   <div class="row">
       <div class="col-6">

--- a/python/django/security/django-no-csrf-token.html
+++ b/python/django/security/django-no-csrf-token.html
@@ -97,3 +97,49 @@
       </div>
   </div>
 </div>
+
+<!-- a nested {% if %} around a multi-line element must not hide the csrf_token -->
+<div class="container">
+  <form method="post">
+      {% csrf_token %}
+      <div>
+          {% if x %}
+              <div>
+                  {{ y }}
+              </div>
+          {% endif %}
+      </div>
+      <div>
+<!-- ok: django-no-csrf-token -->
+          <button type="submit">Go</button>
+      </div>
+  </form>
+</div>
+
+<!-- a longer form without a csrf_token is still reported -->
+<div class="container">
+<!-- ruleid: django-no-csrf-token -->
+  <form method="post">
+      <div class="row-0"><input type="text" name="field_0"></div>
+      <div class="row-1"><input type="text" name="field_1"></div>
+      <div class="row-2"><input type="text" name="field_2"></div>
+      <div class="row-3"><input type="text" name="field_3"></div>
+      <div class="row-4"><input type="text" name="field_4"></div>
+      <div class="row-5"><input type="text" name="field_5"></div>
+      <div class="row-6"><input type="text" name="field_6"></div>
+      <div class="row-7"><input type="text" name="field_7"></div>
+      <div class="row-8"><input type="text" name="field_8"></div>
+      <div class="row-9"><input type="text" name="field_9"></div>
+      <div class="row-10"><input type="text" name="field_10"></div>
+      <div class="row-11"><input type="text" name="field_11"></div>
+      <div class="row-12"><input type="text" name="field_12"></div>
+      <div class="row-13"><input type="text" name="field_13"></div>
+      <div class="row-14"><input type="text" name="field_14"></div>
+      <div class="row-15"><input type="text" name="field_15"></div>
+      <div class="row-16"><input type="text" name="field_16"></div>
+      <div class="row-17"><input type="text" name="field_17"></div>
+      <div class="row-18"><input type="text" name="field_18"></div>
+      <div class="row-19"><input type="text" name="field_19"></div>
+      <button type="submit">Go</button>
+  </form>
+</div>

--- a/python/django/security/django-no-csrf-token.yaml
+++ b/python/django/security/django-no-csrf-token.yaml
@@ -14,6 +14,11 @@ rules:
           regex: (?i)(post|put|delete|patch)
       - pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
       - pattern-not-inside: "<form...>...{{ $VAR.csrf_token }}...</form>"
+    options:
+      # the default limit of 10 newlines per ellipsis is smaller than a realistic
+      # form body, which both hides the csrf_token exemption and stops the rule
+      # from matching longer forms at all
+      generic_ellipsis_max_span: 50
     message: Manually-created forms in django templates should specify a csrf_token to prevent CSRF attacks.
     languages: [generic]
     severity: WARNING


### PR DESCRIPTION
Fixes #3816

## Problem

In generic mode an ellipsis matches at most 10 newlines (`generic_ellipsis_max_span`, default 10). A real form body is longer than that, which breaks the rule in two directions.

Measured on the reporter's templates plus two variants, with the rule as it is on `develop` versus with the option raised:

| template | today | with this change |
|---|---|---|
| 13-line form **with** `{% csrf_token %}` (nested `{% if %}`, multi-line element) | **1 finding — the reported false positive** | 0 |
| 11-line form with `{% csrf_token %}` (same, collapsed to one line) | 0 | 0 |
| 10-line form **without** a token | 1 | 1 |
| 43-line form **without** a token | **0 — silently missed** | **1** |

So the same limit that hides the `{% csrf_token %}` exemption on a slightly larger form also stops the rule from matching longer forms at all. The false negative is the more dangerous half, and it is invisible to users.

## Change

One `options:` block on the rule raising `generic_ellipsis_max_span` to 50, so both the main pattern and the `pattern-not-inside` exemptions reach through a normal form body.

50 is a judgement call — large enough for realistic templates, still bounded. Happy to move it if you'd prefer a different ceiling.

## Tests

`django-no-csrf-token.html` gains the reporter's template as an `ok` case and a longer token-less form as a `ruleid` case (the latter fails without this change).

```
semgrep --test --config python/django/security/django-no-csrf-token.yaml python/django/security/django-no-csrf-token.html
1/1: ✓ All tests passed
```
