### PR TITLE
fix(java): catch chained ProcessBuilder command injection

### DIFF
--- a/java/lang/security/audit/command-injection-process-builder.java
+++ b/java/lang/security/audit/command-injection-process-builder.java
@@ -49,3 +49,36 @@ public class TestExecutor {
 
 
 }
+
+class ProcessBuilderChainedAndLaterArgs {
+    public void chainedCommand(String userInput) {
+        // ruleid: command-injection-process-builder
+        new ProcessBuilder().command(userInput);
+    }
+
+    public void chainedCommandSplit(String userInput) {
+        // ruleid: command-injection-process-builder
+        ProcessBuilder builder = new ProcessBuilder().command(userInput.split(" "));
+    }
+
+    public void dynamicArgInConstructor(String userInput) {
+        // ruleid: command-injection-process-builder
+        ProcessBuilder builder = new ProcessBuilder("ls", userInput);
+    }
+
+    public void dynamicArgInCommand(String userInput) {
+        ProcessBuilder builder = new ProcessBuilder();
+        // ruleid: command-injection-process-builder
+        builder.command("java", "-jar", userInput);
+    }
+
+    public void allArgumentsAreLiterals() {
+        // ok: command-injection-process-builder
+        ProcessBuilder builder = new ProcessBuilder("ls", "-la");
+    }
+
+    public void chainedCommandWithLiterals() {
+        // ok: command-injection-process-builder
+        new ProcessBuilder().command("ls", "-la");
+    }
+}

--- a/java/lang/security/audit/command-injection-process-builder.java
+++ b/java/lang/security/audit/command-injection-process-builder.java
@@ -62,13 +62,13 @@ class ProcessBuilderChainedAndLaterArgs {
     }
 
     public void dynamicArgInConstructor(String userInput) {
-        // ruleid: command-injection-process-builder
+        // ok: command-injection-process-builder
         ProcessBuilder builder = new ProcessBuilder("ls", userInput);
     }
 
     public void dynamicArgInCommand(String userInput) {
         ProcessBuilder builder = new ProcessBuilder();
-        // ruleid: command-injection-process-builder
+        // ok: command-injection-process-builder
         builder.command("java", "-jar", userInput);
     }
 

--- a/java/lang/security/audit/command-injection-process-builder.yaml
+++ b/java/lang/security/audit/command-injection-process-builder.yaml
@@ -38,25 +38,6 @@ rules:
     - pattern-not: |
         new ProcessBuilder().command(Arrays.asList("...",...),...)
   - patterns:
-    - pattern-either:
-      - pattern: |
-          new ProcessBuilder("...",...,$ARG,...)
-      - patterns:
-        - pattern: |
-            $PB.command("...",...,$ARG,...)
-        - pattern-either:
-          - pattern-inside: |
-              $TYPE $PB = new ProcessBuilder(...);
-              ...
-          - pattern: |
-              new ProcessBuilder().command("...",...,$ARG,...)
-    - metavariable-regex:
-        metavariable: $ARG
-        regex: ^(?!").
-    - pattern-not-inside: |
-        $ARG = "...";
-        ...
-  - patterns:
     - pattern: |
         $PB.command($CMD,...)
     - pattern-inside: |

--- a/java/lang/security/audit/command-injection-process-builder.yaml
+++ b/java/lang/security/audit/command-injection-process-builder.yaml
@@ -21,6 +21,43 @@ rules:
         new ProcessBuilder(Arrays.asList("...",...),...)
   - patterns:
     - pattern: |
+        new ProcessBuilder().command($CMD,...)
+    - pattern-not-inside: |
+        $CMD = "...";
+        ...
+    - pattern-not-inside: |
+        $CMD = Arrays.asList("...",...);
+        ...
+    - pattern-not-inside: |
+        $CMD = new String[]{"...",...};
+        ...
+    - pattern-not: |
+        new ProcessBuilder().command("...",...)
+    - pattern-not: |
+        new ProcessBuilder().command(new String[]{"...",...},...)
+    - pattern-not: |
+        new ProcessBuilder().command(Arrays.asList("...",...),...)
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          new ProcessBuilder("...",...,$ARG,...)
+      - patterns:
+        - pattern: |
+            $PB.command("...",...,$ARG,...)
+        - pattern-either:
+          - pattern-inside: |
+              $TYPE $PB = new ProcessBuilder(...);
+              ...
+          - pattern: |
+              new ProcessBuilder().command("...",...,$ARG,...)
+    - metavariable-regex:
+        metavariable: $ARG
+        regex: ^(?!").
+    - pattern-not-inside: |
+        $ARG = "...";
+        ...
+  - patterns:
+    - pattern: |
         $PB.command($CMD,...)
     - pattern-inside: |
         $TYPE $PB = new ProcessBuilder(...);


### PR DESCRIPTION
Fixes #3814

## Problem

The existing rule misses chained calls where the command itself is dynamic:

| code | before | after |
|---|---|---|
| `new ProcessBuilder().command(userInput)` | missed | reported |
| `new ProcessBuilder().command(userInput.split(" "))` | missed | reported |
| `new ProcessBuilder(userInput)` (control) | reported | reported |
| `new ProcessBuilder("ls", userInput)` | not reported | not reported |
| `builder.command("java", "-jar", userInput)` | not reported | not reported |
| `new ProcessBuilder("ls", "-la")` | not reported | not reported |

The `command()` branch requires `pattern-inside: $TYPE $PB = new ProcessBuilder(...)`, so a chained call on a fresh builder has no matching assignment.

## Change

Add a chained-receiver branch for `new ProcessBuilder().command(...)`, carrying the same literal/`Arrays.asList`/`String[]` exclusions as the existing branch.

After review, the proposed later-argument branch was removed: `ProcessBuilder` passes separate arguments directly to the child process, so a dynamic later argument is not command injection unless the executable is itself a shell. The existing `sh -c` / `cmd /c` branches continue to cover those cases. Tests now explicitly mark ordinary later dynamic arguments as `ok` to prevent that false positive from returning.

## Tests

```
semgrep --test java/lang/security/audit/command-injection-process-builder.java --config java/lang/security/audit/command-injection-process-builder.yaml
1/1: ✓ All tests passed
```