### PR TITLE
fix(java): recognize SharedSessionContract in hibernate-sqli

### DIFF
--- a/java/lang/security/audit/sqli/hibernate-sqli.java
+++ b/java/lang/security/audit/sqli/hibernate-sqli.java
@@ -2,6 +2,7 @@ package testcode.sqli;
 
 import org.hibernate.Criteria;
 import org.hibernate.Session;
+import org.hibernate.SharedSessionContract;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.type.StandardBasicTypes;
@@ -42,5 +43,15 @@ public class HibernateSql {
         // ok: hibernate-sqli
         criteria.add(Restrictions.sqlRestriction("param1  = ? and param2 = ?", new String[] {input}, new Type[] {StandardBasicTypes.STRING}));
 
+    }
+
+    public void testSharedSessionContract(SessionFactory sessionFactory, String input) {
+        SharedSessionContract session = sessionFactory.openSession();
+        String hql = "from UserEntity where name = '" + input + "'";
+        // ruleid: hibernate-sqli
+        session.createQuery(hql);
+
+        // ok: hibernate-sqli
+        session.createQuery("from UserEntity");
     }
 }

--- a/java/lang/security/audit/sqli/hibernate-sqli.yaml
+++ b/java/lang/security/audit/sqli/hibernate-sqli.yaml
@@ -48,7 +48,14 @@ rules:
           org.hibernate.Session $SESSION = ...;
           ...
       - pattern-inside: |
+          org.hibernate.SharedSessionContract $SESSION = ...;
+          ...
+      - pattern-inside: |
           $TYPE $FUNC(...,org.hibernate.Session $SESSION,...) {
+            ...
+          }
+      - pattern-inside: |
+          $TYPE $FUNC(...,org.hibernate.SharedSessionContract $SESSION,...) {
             ...
           }
     - pattern-not: |


### PR DESCRIPTION
Addresses case 1 of #3817.

## Problem

`hibernate-sqli` only tracks a dynamic query when the receiver is typed as `org.hibernate.Session`. The same HQL executed through a `SharedSessionContract` is missed:

```java
SharedSessionContract session = sessionFactory.openSession();
String hql = "from UserEntity where name = '" + input + "'";
session.createQuery(hql);   // not flagged before this change
```

`SharedSessionContract` is the common supertype of `Session` and `StatelessSession` and is a normal declared type for a session handle, so `createQuery` / `createSQLQuery` called on it is the same sink.

## Change

Adds `SharedSessionContract` next to `Session` in the receiver-type alternatives, for both the local-variable and method-parameter shapes. All the existing guards (the `"..." + "..."` exclusions, the `createQuery|createSQLQuery` method filter) apply unchanged, so a constant query on a `SharedSessionContract` is still not flagged.

The StringBuilder case from the issue is intentionally left out: tracking a query assembled via `StringBuilder.append(...).toString()` needs more than a receiver-type addition (and my first attempt at a `pattern-inside` for it made the rule fail to parse), so it's better handled as a separate change than bundled in loosely here.

## Tests

`hibernate-sqli.java` gains a `testSharedSessionContract` method with the reproducer as `ruleid` and a constant query as `ok`.

```
semgrep --test --config java/lang/security/audit/sqli/hibernate-sqli.yaml java/lang/security/audit/sqli/hibernate-sqli.java
1/1: ✓ All tests passed
```
