### PR TITLE
fix(java): avoid eqeq false positives on null checks

### DIFF
--- a/java/lang/correctness/eqeq.java
+++ b/java/lang/correctness/eqeq.java
@@ -21,3 +21,19 @@ class Bar {
         }
     }
 }
+
+class TernaryCondition {
+    void main() {
+        BooleanExpression expr = null;
+        BooleanExpression other = null;
+
+        // ok:eqeq
+        expr = (expr != null ? expr.and(other) : other);
+    }
+}
+
+class BooleanExpression {
+    BooleanExpression and(BooleanExpression other) {
+        return other;
+    }
+}

--- a/java/lang/correctness/eqeq.yaml
+++ b/java/lang/correctness/eqeq.yaml
@@ -8,6 +8,10 @@ rules:
           - pattern: $X == $X
           - pattern: $X != $X
       - pattern-not: 1 == 1
+      - pattern-not: $X == null
+      - pattern-not: $X != null
+      - pattern-not: null == $X
+      - pattern-not: null != $X
     message: >-
       `$X == $X` or `$X != $X` is always true. (Unless the value compared is a float
       or double).


### PR DESCRIPTION
## Summary
- exclude Java null comparisons from the `eqeq` self-comparison rule
- add a regression fixture for the ternary null-guard shape reported in #4019

## Rationale
The rule is meant to report expressions like `x == x` or `x != x`. A ternary guard such as `expr != null ? ... : ...` is valid control flow and should not be reported as a self-comparison.

Fixes #4019.

## Validation
- `uvx semgrep --test --config java/lang/correctness/eqeq.yaml java/lang/correctness/eqeq.java`
- `uvx semgrep --validate --config java/lang/correctness/eqeq.yaml`
- `uvx semgrep --test --config java/lang/correctness java/lang/correctness`
- `git diff --check`