### PR TITLE
Fix Renovate minimum release age exception

### DIFF
--- a/package_managers/renovate/renovate-missing-minimum-release-age.test.json
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.test.json
@@ -110,7 +110,7 @@
     {
       "matchPackageNames": ["webpack"],
       "groupName": "Webpack build system",
-      // ruleid: renovate-missing-minimum-release-age
+      // ok: renovate-missing-minimum-release-age
       "minimumReleaseAge": "0 days"
     },
     {
@@ -195,7 +195,7 @@
     },
     {
       "matchPackageNames": ["webpack"],
-      // ok: renovate-missing-minimum-release-age
+      // ruleid: renovate-missing-minimum-release-age
       "minimumReleaseAge": false
     }
   ]

--- a/package_managers/renovate/renovate-missing-minimum-release-age.yaml
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.yaml
@@ -24,7 +24,7 @@ rules:
           - pattern-not: |
               {
                 ...,
-                "minimumReleaseAge": false,
+                "minimumReleaseAge": "0 days",
                 ...
               }
       # Branch 2: Present but too low
@@ -36,7 +36,7 @@ rules:
           - pattern-regex: '"minimumReleaseAge":\s*"(?P<AGE>\d+) days?"'
           - metavariable-comparison:
               metavariable: $AGE
-              comparison: int($AGE) < 7
+              comparison: int($AGE) > 0 and int($AGE) < 7
           - focus-metavariable: $AGE
       # Branch 3: Invalid format (not matching "N days")
       - patterns:
@@ -50,13 +50,21 @@ rules:
               metavariable: $AGE
               regex: '^(?!\d+ days?$)'
           - focus-metavariable: $AGE
+      # Branch 4: Invalid boolean exception
+      - patterns:
+          - pattern-inside: |
+              "packageRules": [
+                ...
+              ]
+          - pattern: |
+              "minimumReleaseAge": false
     message: >-
       This Renovate configuration does not set a minimum release age.
       Newly published packages can be malicious or unstable.
       Add `"minimumReleaseAge": "7 days"` within a `packageRules`
       entry to wait 7 days before proposing updates to newly
       published package versions.
-      Set `"minimumReleaseAge": false` to set an exception for minimal release age for the package rule.
+      Set `"minimumReleaseAge": "0 days"` to make an exception for the package rule.
       Added in: v42
     languages:
       - json


### PR DESCRIPTION
## Summary

- recommend the valid `"minimumReleaseAge": "0 days"` Renovate exception
- treat the invalid boolean value `false` as a finding
- keep explicit exceptions out of the 1–6 day minimum-age check

## Root cause

The rule documented and exempted `false`, but Renovate requires `minimumReleaseAge` to be a string. Using the suggested value therefore makes Renovate reject the repository configuration.

## Validation

- `semgrep test package_managers/renovate`
- `semgrep validate package_managers/renovate`

Closes #4018