### PR TITLE
fix(java): catch permissive file permission APIs

### DIFF
--- a/java/lang/security/audit/overly-permissive-file-permission.java
+++ b/java/lang/security/audit/overly-permissive-file-permission.java
@@ -1,8 +1,10 @@
 package testcode.file.permissions;
 
 import java.io.IOException;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashSet;
@@ -37,8 +39,42 @@ public class FileApi {
         Files.setPosixFilePermissions(Paths.get("/var/opt/app/init_script.sh"),perms);
     }
 
+    public static void notOk3() throws IOException {
+        File file = new File("/var/opt/configuration.xml");
+        // ruleid:overly-permissive-file-permission
+        file.setReadable(true, false);
+        // ruleid:overly-permissive-file-permission
+        file.setWritable(true, false);
+        // ruleid:overly-permissive-file-permission
+        file.setExecutable(true, false);
+    }
+
+    public static void notOk4() throws IOException {
+        PosixFileAttributeView attrs = Files.getFileAttributeView(
+                Paths.get("/var/opt/configuration.xml"), PosixFileAttributeView.class);
+        // ruleid:overly-permissive-file-permission
+        attrs.setPermissions(PosixFilePermissions.fromString("rw-rw-rw-"));
+        // ruleid:overly-permissive-file-permission
+        Files.createTempDirectory(
+                "temp-",
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-rw-rw-")));
+        // ruleid:overly-permissive-file-permission
+        Files.createTempFile(
+                Paths.get("/tmp"),
+                "prefix",
+                "suffix",
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--")));
+        // ruleid:overly-permissive-file-permission
+        Files.createFile(
+                Paths.get("/var/opt/configuration.xml"),
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-rw-rw-")));
+    }
+
     public static void ok() throws IOException {
         Files.setPosixFilePermissions(Paths.get("/var/opt/configuration.xml"), PosixFilePermissions.fromString("rw-rw----"));
         Files.setPosixFilePermissions(Paths.get("/var/opt/configuration.xml"), PosixFilePermissions.fromString("rwxrwx---"));
+        new File("/var/opt/configuration.xml").setReadable(true, true);
+        new File("/var/opt/configuration.xml").setWritable(false, false);
+        new File("/var/opt/configuration.xml").setExecutable(true, true);
     }
 }

--- a/java/lang/security/audit/overly-permissive-file-permission.yaml
+++ b/java/lang/security/audit/overly-permissive-file-permission.yaml
@@ -30,7 +30,14 @@ rules:
     impact: MEDIUM
     confidence: LOW
   pattern-either:
+  - pattern: $FILE.setReadable(true, false);
+  - pattern: $FILE.setWritable(true, false);
+  - pattern: $FILE.setExecutable(true, false);
   - pattern: java.nio.file.Files.setPosixFilePermissions($FILE, java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/"));
+  - pattern: $ATTRS.setPermissions(java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/"));
+  - pattern: java.nio.file.Files.createFile($FILE, java.nio.file.attribute.PosixFilePermissions.asFileAttribute(java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/")));
+  - pattern: java.nio.file.Files.createTempDirectory(..., java.nio.file.attribute.PosixFilePermissions.asFileAttribute(java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/")));
+  - pattern: java.nio.file.Files.createTempFile(..., java.nio.file.attribute.PosixFilePermissions.asFileAttribute(java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/")));
   - pattern: |
       $TYPE $P = java.nio.file.attribute.PosixFilePermissions.fromString("=~/(^......r..$)|(^.......w.$)|(^........x$)/");
       ...


### PR DESCRIPTION
## Summary
- extend `java.lang.security.audit.overly-permissive-file-permission` to catch `java.io.File` permission setters when `ownerOnly=false`
- catch permissive `PosixFilePermissions.fromString(...)` values passed through `PosixFileAttributeView.setPermissions` and NIO file creation attributes
- add Java regression cases for the missed APIs reported in #3818

## Validation
- `uvx semgrep --test --config java/lang/security/audit/overly-permissive-file-permission.yaml java/lang/security/audit/overly-permissive-file-permission.java`
- `uvx semgrep --validate --config java/lang/security/audit/overly-permissive-file-permission.yaml`
- `uvx semgrep --test --config java/lang/security/audit java/lang/security/audit`
- `uvx semgrep --test --config java/lang/security java/lang/security`
- `git diff --check`

This addresses the concrete legacy `java.io.File` and alternative NIO sink false negatives from #3818.