### PR TITLE
feat(python): add static detection rules for un-gated AI agent tool execution and excessive agency

### DIFF
--- a/python/langchain/security/ai-agent-action-gate.py
+++ b/python/langchain/security/ai-agent-action-gate.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import requests
+
+def vulnerable_agent_handler(agent_tool_call, agent_output, cursor, db):
+    # ruleid: un-gated-agent-tool-execution
+    subprocess.run(agent_tool_call.get("command"), shell=True)
+
+    # ruleid: un-gated-agent-tool-execution
+    os.system(agent_output)
+
+    # ruleid: un-gated-agent-tool-execution
+    cursor.execute(agent_output)
+
+    # ruleid: un-gated-agent-tool-execution
+    requests.delete(agent_output)
+
+def vulnerable_confidence_bypass(agent_decision, tool):
+    # ruleid: never-equate-intent-to-approval
+    if agent_decision.confidence > 0.95:
+        tool.execute()
+
+def safe_guarded_agent_handler(action_boundary, agent_output):
+    # ok: un-gated-agent-tool-execution
+    guarded_func = action_boundary.guard(lambda x: print(x))
+    guarded_func(agent_output)

--- a/python/langchain/security/ai-agent-action-gate.yaml
+++ b/python/langchain/security/ai-agent-action-gate.yaml
@@ -1,0 +1,67 @@
+rules:
+- id: un-gated-agent-tool-execution
+  message: >-
+    Detected un-gated AI agent tool execution. Passing LLM/agent output directly to mutating execution sinks 
+    (such as shell commands, SQL queries, or state-modifying APIs) without an ActionBoundary or human-in-the-loop 
+    prove token violates the zero-trust execution principle ('never_equate_intent_to_approval: true') and 
+    exposes systems to OWASP LLM06 (Excessive Agency). Wrap tool execution in an ActionBoundary or ActionGate.
+  severity: WARNING
+  languages:
+  - python
+  metadata:
+    cwe:
+    - "CWE-250: Execution with Unnecessary Privileges"
+    - "CWE-862: Missing Authorization"
+    - "CWE-863: Incorrect Authorization"
+    - "OWASP-LLM06: Excessive Agency"
+    category: security
+    technology:
+    - langchain
+    - crewai
+    - autogen
+    - llama-index
+    confidence: HIGH
+    references:
+    - https://owasp.org/www-project-top-10-for-large-language-model-applications/
+    - https://a2zsoc.com/productized-services#instant-audit-tripwire
+  patterns:
+  - pattern-either:
+    - pattern: |
+        subprocess.run($AGENT_TOOL_CALL.get(...), ...)
+    - pattern: |
+        subprocess.Popen($AGENT_TOOL_CALL.get(...), ...)
+    - pattern: |
+        os.system($AGENT_OUTPUT)
+    - pattern: |
+        $CURSOR.execute($AGENT_OUTPUT)
+    - pattern: |
+        $DB.session.execute($AGENT_OUTPUT)
+    - pattern: |
+        requests.delete($AGENT_OUTPUT, ...)
+    - pattern: |
+        requests.post($AGENT_OUTPUT, ...)
+
+- id: never-equate-intent-to-approval
+  message: >-
+    Detected direct execution bypass based solely on LLM agent confidence or intent string without a cryptographic 
+    prove token or deterministic ActionGate. Model confidence cannot be equated to authorization in production 
+    agent swarms.
+  severity: ERROR
+  languages:
+  - python
+  metadata:
+    cwe:
+    - "CWE-862: Missing Authorization"
+    - "OWASP-LLM06: Excessive Agency"
+    category: security
+    technology:
+    - ai-agents
+    - langchain
+    - autogen
+    confidence: MEDIUM
+    references:
+    - https://a2zsoc.com/consultation
+  patterns:
+  - pattern: |
+      if $AGENT_DECISION.confidence > $THRESHOLD:
+          $TOOL.execute(...)


### PR DESCRIPTION
### Summary
Adds static detection rules for un-gated AI agent tool execution and excessive agency (`OWASP-LLM06`) under `python/langchain/security/ai-agent-action-gate.yaml`.

### Problem Solved
As engineering teams build agentic workflows across LangChain, CrewAI, AutoGen, and LlamaIndex, developers frequently pass raw LLM/agent output strings directly into mutating execution sinks (`subprocess.run`, `os.system`, `cursor.execute`, `requests.post/delete`) or bypass verification based solely on model confidence without an `ActionBoundary` or prove token.

This rule pack flags:
1. **`un-gated-agent-tool-execution`**: Identifies unconstrained execution of shell commands, database queries, and state-modifying HTTP calls from agent outputs without an ActionBoundary.
2. **`never-equate-intent-to-approval`**: Identifies confidence-based execution bypasses in agent swarms.

### Testing & Validation
- Added `python/langchain/security/ai-agent-action-gate.py` with `# ruleid:` test annotations covering true-positive sinks (subprocess, os.system, cursor execute, requests.delete) and true-negative guarded patterns (`action_boundary.guard`).

### Upstream & Commercial Context
Maintained by [A2Z SOC](https://a2zsoc.com) for AI runtime governance and AppSec compliance audit readiness.

For teams building AI agents requiring static analysis audits, AI safety reviews, or ISO 42001 / SOC 2 readiness sprints:
- **Instant Audit ($499):** https://a2zsoc.com/productized-services#instant-audit-tripwire
- **Consultation & AppSec Sprints:** https://a2zsoc.com/consultation
