### PR TITLE
python/flask: catch inline render_template_string() calls in dangerous-template-string

### DIFF
--- a/python/flask/security/dangerous-template-string.py
+++ b/python/flask/security/dangerous-template-string.py
@@ -28,18 +28,18 @@ def error2(e):
 ''' % (request.url)
     return flask.render_template_string(template), 404
 
-## Doesn't work yet
-#@app.route("/error3")
-#def error3(e):
-#    template = f'''{  extends "layout.html"  }
-#{  block body  }
-#    <div class="center-content error">
-#        <h1>Oops! That page doesn't exist.</h1>
-#        <h3>{request.url}</h3>
-#    </div>
-#{  endblock  }
-#'''
-#    return flask.render_template_string(template)
+@app.route("/error3")
+def error3(e):
+    # ruleid: dangerous-template-string
+    template = f'''{{  extends "layout.html"  }}
+{{  block body  }}
+    <div class="center-content error">
+        <h1>Oops! That page doesn't exist.</h1>
+        <h3>{request.url}</h3>
+    </div>
+{{  endblock  }}
+'''
+    return flask.render_template_string(template)
 
 @app.route("/error4")
 def error4(e):
@@ -58,3 +58,38 @@ def error4(e):
 {  endblock  }
 """
     rendered = flask.render_template_string(template)
+
+@app.route("/inline_fstring")
+def inline_fstring():
+    # ruleid: dangerous-template-string
+    return flask.render_template_string(f"<h1>{request.url}</h1>")
+
+@app.route("/inline_fstring_tuple")
+def inline_fstring_tuple():
+    # ruleid: dangerous-template-string
+    return flask.render_template_string(f"<h1>{request.url}</h1>"), 404
+
+@app.route("/inline_format")
+def inline_format():
+    # ruleid: dangerous-template-string
+    return flask.render_template_string("<h1>{}</h1>".format(request.url))
+
+@app.route("/inline_percent")
+def inline_percent():
+    # ruleid: dangerous-template-string
+    return flask.render_template_string("<h1>%s</h1>" % request.url)
+
+@app.route("/inline_concat")
+def inline_concat():
+    # ruleid: dangerous-template-string
+    return flask.render_template_string("<h1>" + request.url + "</h1>")
+
+@app.route("/safe_context")
+def safe_context():
+    # ok: dangerous-template-string
+    return flask.render_template_string("<h1>{{ url }}</h1>", url=request.url)
+
+@app.route("/safe_constant")
+def safe_constant():
+    # ok: dangerous-template-string
+    return flask.render_template_string("<h1>static</h1>")

--- a/python/flask/security/dangerous-template-string.yaml
+++ b/python/flask/security/dangerous-template-string.yaml
@@ -60,3 +60,7 @@ rules:
       $V = f"...{$X}..."
       ...
       return flask.render_template_string($V, ...), $CODE
+  - pattern: flask.render_template_string(f"...{$X}...", ...)
+  - pattern: flask.render_template_string("...".format(...), ...)
+  - pattern: flask.render_template_string("..." % $X, ...)
+  - pattern: flask.render_template_string($A + $B, ...)


### PR DESCRIPTION
### What

`dangerous-template-string` requires the template to be assigned to a variable before the call, so a template formatted inline at the call site is missed entirely:

```python
# not flagged today
return flask.render_template_string(f"<h1>{request.url}</h1>")
```

All eight existing patterns are of the form `$V = <formatted> ... render_template_string($V)`. This adds four that match the call expression itself — f-string, `.format`, `%`, concatenation. Matching the expression also covers `return render_template_string(...), 404` for free, which is why the existing set needs two entries per formatting style.

### The commented-out test

`dangerous-template-string.py` carries an `error3` case commented out as `## Doesn't work yet`. The assignment-plus-f-string form it describes is matched today; the block could never have passed because `f'''{  extends "layout.html"  }'''` is not valid Python — the braces are parsed as f-string expressions. Rewritten with escaped braces so it parses, and enabled.

### Tests

Five vulnerable cases and two `# ok:` cases added. The `# ok:` half is deliberate: it pins the rule against being widened into flagging every `render_template_string` call, which `flask/security/audit/render-template-string` already does at WARNING.

`semgrep --test` passes 1/1 on the rule.
