### PR TITLE
fix(generic-api-key): exclude pnpm-workspace.yaml

### DIFF
--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -38,6 +38,7 @@ rules:
       - "*package-lock.json"
       - "*bundle.js"
       - "*pnpm-lock*"
+      - "*pnpm-workspace.yaml"
       - "*Podfile.lock"
       - "**/*/openssl/*.h"
       - "*.xcscmblueprint"


### PR DESCRIPTION
**AI Disclaimer**: I created this PR with Claude after verifying the issue in our pnpm repos manually.

`pnpm-workspace.yaml` is pnpm's workspace manifest. Since pnpm 9.5 its `catalog:` / `catalogs:` blocks pin dependency versions, which makes it a dependency manifest in the same sense as the `package.json` and `pnpm-lock` entries this rule's `paths.exclude` already carries — catalogs are simply newer than the list.

A catalog entry matches the rule when the package name happens to contain one of its keywords (`key`, `api`, `token`, `secret`, `client`, `auth`, `access`, ...) and the pinned version is long enough to clear the value filters — which an ordinary semver string does as soon as it carries a pre-release or build-metadata suffix.

### Reproduction

`pnpm-workspace.yaml`:

```yaml
packages:
  - packages/*

catalog:
  "@scope/widget-api": 30.0.0-pre.3
  "@scope/widget-core": 30.0.0-pre.3
  "@scope/widget-auth": 30.0.0
```

```
$ semgrep scan --config p/gitleaks --no-git-ignore .
Ran 174 rules on 1 file: 1 finding.

    5| "@scope/widget-api": 30.0.0-pre.3
```

With this patch applied, the same file is clean:

```
Ran 173 rules on 1 file: 0 findings.
```

`widget-core` (no keyword in the key) and `widget-auth: 30.0.0` (value too short) stay silent in both runs, so the trigger is the keyword-plus-length combination rather than anything secret-shaped.

Package names ending in `-api`, `-client` or `-auth` are common, so during a pre-release cycle this reports every such pin as a hard-coded credential.

No test change: `paths.exclude` is path-based and the rule's test harness is a single `generic-api-key.txt`, so the exclusion is not exercisable there.
