### PR TITLE
Exclude `$/` self-repository refs from action pinning rules

### DIFF
--- a/yaml/github-actions/security/audit/third-party-action-not-pinned-to-commit-sha.test.yml
+++ b/yaml/github-actions/security/audit/third-party-action-not-pinned-to-commit-sha.test.yml
@@ -24,6 +24,11 @@ jobs:
           arg1: ${{ secrets.supersecret1 }}
 
       # ok: third-party-action-not-pinned-to-commit-sha
+      - uses: $/.github/actions/do-an-internal-action
+        with:
+          arg1: ${{ secrets.supersecret1 }}
+
+      # ok: third-party-action-not-pinned-to-commit-sha
       - uses: completely/fakeaction@5fd3084fc36e372ff1fff382a39b10d03659f355
         with:
           arg2: ${{ secrets.supersecret2 }}

--- a/yaml/github-actions/security/audit/third-party-action-not-pinned-to-commit-sha.yml
+++ b/yaml/github-actions/security/audit/third-party-action-not-pinned-to-commit-sha.yml
@@ -10,6 +10,9 @@ rules:
           patterns:
             # Locally-defined action
             - pattern-not-regex: "^[.]/"
+            # Same-repository action: `$/` resolves to the workflow's own
+            # repository at the commit that is running
+            - pattern-not-regex: "^[$]/"
             # GitHub-owned action
             - pattern-not-regex: "^actions/"
             # GitHub-owned action

--- a/yaml/github-actions/security/github-actions-mutable-action-tag.test.yaml
+++ b/yaml/github-actions/security/github-actions-mutable-action-tag.test.yaml
@@ -37,6 +37,10 @@ jobs:
       # ok: github-actions-mutable-action-tag
       - uses: ./.github/actions/my-local-action
 
+      # TN: same-repository reference (resolves to this repo at the running commit)
+      # ok: github-actions-mutable-action-tag
+      - uses: $/.github/actions/my-internal-action
+
       # TN: docker action reference (no owner/repo@)
       # ok: github-actions-mutable-action-tag
       - uses: docker://alpine:3.18

--- a/yaml/github-actions/security/github-actions-mutable-action-tag.yaml
+++ b/yaml/github-actions/security/github-actions-mutable-action-tag.yaml
@@ -36,5 +36,9 @@ rules:
           language: generic
           patterns:
             - pattern-not-regex: '^\./'
+            # Same-repository reference: `$/` resolves to the workflow's own
+            # repository at the commit that is running, so it cannot be
+            # repointed and needs no SHA.
+            - pattern-not-regex: '^\$/'
             - pattern-not-regex: '^docker://'
             - pattern-not-regex: '@[0-9a-f]{40}(\s|$)'


### PR DESCRIPTION
`github-actions-mutable-action-tag` and
`third-party-action-not-pinned-to-commit-sha` both flag
`uses: $/.github/actions/my-action` as an unpinned third-party action.
It is neither.

`$/` is GitHub's self-repository reference, added in July 2026. It
resolves to the workflow's own repository at the exact commit that is
running, so the referenced action cannot be repointed by anyone else,
and no SHA is needed or possible:

https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

It is the same class of reference as the workspace-relative `./`, which
both rules already exclude, and the docs recommend it over `./` for
sibling actions and reusable workflows because it needs no checkout and
follows the caller's ref.

Both rules currently exclude `./`, `docker://` and 40-character SHAs and
read everything else as third-party and unpinned, so every `$/`
reference is a false positive. Repositories that keep their internal
actions alongside their workflows hit one on every such step.

Each rule gains a true-negative case in its test file.