### PR TITLE
Add mcp-credential-destination-injection-python rule

### DIFF
--- a/ai/ai-best-practices/mcp-credential-destination-injection/mcp-credential-destination-injection.py
+++ b/ai/ai-best-practices/mcp-credential-destination-injection/mcp-credential-destination-injection.py
@@ -1,0 +1,56 @@
+import requests
+import httpx
+import urllib.parse
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("test-server")
+
+
+@mcp.tool()
+def fetch_with_bearer(url: str, token: str) -> str:
+    # ruleid: mcp-credential-destination-injection-python
+    response = requests.get(url, headers={"Authorization": f"Bearer {token}"})
+    return response.text
+
+
+@mcp.tool()
+def post_with_bearer(url: str, token: str) -> str:
+    # ruleid: mcp-credential-destination-injection-python
+    response = requests.post(url, headers={"Authorization": f"Bearer {token}"})
+    return response.text
+
+
+@mcp.tool()
+def fetch_with_auth_tuple(url: str, api_key: str) -> str:
+    # ruleid: mcp-credential-destination-injection-python
+    response = requests.get(url, auth=(api_key, ""))
+    return response.text
+
+
+@mcp.tool()
+def fetch_httpx_with_bearer(url: str, token: str) -> str:
+    # ruleid: mcp-credential-destination-injection-python
+    response = httpx.get(url, headers={"Authorization": f"Bearer {token}"})
+    return response.text
+
+
+@mcp.tool()
+def fetch_no_credential(url: str) -> str:
+    # ok: mcp-credential-destination-injection-python
+    response = requests.get(url)
+    return response.text
+
+
+@mcp.tool()
+def fetch_validated_destination(url: str, token: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    # ok: mcp-credential-destination-injection-python
+    response = requests.get(parsed.geturl(), headers={"Authorization": f"Bearer {token}"})
+    return response.text
+
+
+@mcp.tool()
+def fetch_hardcoded_destination(token: str) -> str:
+    # ok: mcp-credential-destination-injection-python
+    response = requests.get("https://api.example.com/data", headers={"Authorization": f"Bearer {token}"})
+    return response.text

--- a/ai/ai-best-practices/mcp-credential-destination-injection/mcp-credential-destination-injection.yaml
+++ b/ai/ai-best-practices/mcp-credential-destination-injection/mcp-credential-destination-injection.yaml
@@ -1,0 +1,51 @@
+rules:
+  - id: mcp-credential-destination-injection-python
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: >-
+      User input from an MCP tool handler flows into the destination of an
+      HTTP request that also carries a credential (an Authorization header,
+      bearer token, or auth parameter). An attacker who controls the tool
+      argument can redirect the credential to a destination of their
+      choosing. Validate the destination against a trusted allowlist before
+      attaching any credential to the request; do not rely on the initial
+      request alone if redirects are followed.
+    metadata:
+      cwe: "CWE-918: Server-Side Request Forgery (SSRF)"
+      category: security
+      confidence: MEDIUM
+      subcategory: [vuln]
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [mcp]
+      references:
+        - https://modelcontextprotocol.io/specification/draft/basic/security_best_practices
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              @$SERVER.tool()
+              def $FUNC(..., $PARAM, ...):
+                  ...
+          - focus-metavariable: $PARAM
+    pattern-sinks:
+      - patterns:
+          - pattern: 'requests.get($SINK, headers={..., "Authorization": $CRED, ...}, ...)'
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: 'requests.post($SINK, headers={..., "Authorization": $CRED, ...}, ...)'
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: requests.get($SINK, auth=$AUTH, ...)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: requests.post($SINK, auth=$AUTH, ...)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: 'httpx.get($SINK, headers={..., "Authorization": $CRED, ...}, ...)'
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern: 'httpx.post($SINK, headers={..., "Authorization": $CRED, ...}, ...)'
+          - focus-metavariable: $SINK
+    pattern-sanitizers:
+      - pattern: urllib.parse.urlparse(...)


### PR DESCRIPTION
## Summary

Adds a new rule to the `ai/ai-best-practices/` MCP category: **mcp-credential-destination-injection-python**.

Detects an MCP tool argument flowing into the destination of an HTTP request that also carries a credential (an `Authorization` header, bearer token, or `auth` parameter).

This is a distinct pattern from the two existing rules it sits next to:
- `mcp-ssrf` flags any tainted URL reaching a request call, regardless of whether a credential is attached.
- `mcp-credential-in-response` flags a credential leaking back through a tool's *return value*.

Here the credential never leaks and the request itself is unremarkable — the issue is that the **destination** is chosen by untrusted input while a credential rides along. An attacker who controls the tool argument can redirect the server's own credential to a destination of their choosing. This is the mechanism behind a recently disclosed SSRF in an official cloud vendor's MCP server (CVE-2026-14540), where a redirect carried a credentialed request to a cloud instance metadata endpoint.

## What's included

- `mcp-credential-destination-injection.yaml` — taint-mode rule covering `requests`/`httpx` with `headers={"Authorization": ...}` and `auth=` sinks, following the same source pattern (`@server.tool()` handler parameter) as the existing `mcp-ssrf` rule.
- `mcp-credential-destination-injection.py` — test file with `ruleid`/`ok` cases (credential+tainted destination fires; no credential, sanitized destination, or hardcoded destination do not fire).

Verified locally with `semgrep --test` — all cases pass.

## Test plan

- [x] `semgrep --test ai/ai-best-practices/mcp-credential-destination-injection` passes locally
- [x] Checked for overlap with existing MCP rules in this repo (`mcp-ssrf`, `mcp-credential-in-response`, `mcp-hardcoded-config-secret`) — none cover this pattern