### PR TITLE
feat: detect root users in Docker Compose services

### DIFF
--- a/yaml/docker-compose/security/service-runs-as-root.test.yaml
+++ b/yaml/docker-compose/security/service-runs-as-root.test.yaml
@@ -1,0 +1,50 @@
+services:
+  named-root:
+    image: nginx:alpine
+    # ruleid: service-runs-as-root
+    user: root
+  named-root-with-group:
+    build: .
+    # ruleid: service-runs-as-root
+    user: root:root
+  quoted-named-root:
+    image: nginx:alpine
+    # ruleid: service-runs-as-root
+    user: "root"
+  numeric-root:
+    image: nginx:alpine
+    # ruleid: service-runs-as-root
+    user: 0
+  quoted-numeric-root-with-group:
+    image: nginx:alpine
+    # ruleid: service-runs-as-root
+    user: "0:1000"
+  non-root-name:
+    image: nginx:alpine
+    # ok: service-runs-as-root
+    user: app
+  root-prefixed-name:
+    image: nginx:alpine
+    # ok: service-runs-as-root
+    user: rootless
+  non-root-id:
+    image: nginx:alpine
+    # ok: service-runs-as-root
+    user: 1000
+  root-group-only:
+    image: nginx:alpine
+    # ok: service-runs-as-root
+    user: app:root
+  interpolated-user:
+    image: nginx:alpine
+    # ok: service-runs-as-root
+    user: "${APP_UID:-1000}:${APP_GID:-1000}"
+  nested-configuration:
+    image: nginx:alpine
+    x-process-settings:
+      # ok: service-runs-as-root
+      user: root
+
+x-service-template:
+  # ok: service-runs-as-root
+  user: root

--- a/yaml/docker-compose/security/service-runs-as-root.yaml
+++ b/yaml/docker-compose/security/service-runs-as-root.yaml
@@ -1,0 +1,41 @@
+rules:
+- id: service-runs-as-root
+  patterns:
+  - pattern: |
+      services:
+        ...
+        $SERVICE:
+          ...
+          user: $USER
+          ...
+  - metavariable-regex:
+      metavariable: $USER
+      regex: ^['"]?(root|0)(:.*)?['"]?$
+  - focus-metavariable: $USER
+  message: >-
+    Service '$SERVICE' explicitly runs as root because 'user' is set to
+    '$USER'. Running processes as root increases the impact of a container
+    compromise. Set 'user' to a non-root user name or UID and ensure the image
+    supports it.
+  metadata:
+    cwe:
+    - 'CWE-250: Execution with Unnecessary Privileges'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    - A02:2025 - Security Misconfiguration
+    references:
+    - https://docs.docker.com/reference/compose-file/services/#user
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user
+    category: security
+    technology:
+    - docker-compose
+    vulnerability_class:
+    - Insecure Configuration
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: HIGH
+  languages:
+  - yaml
+  severity: WARNING


### PR DESCRIPTION
## Link to an issue, if relevant

Fixes #4036

### Adding a new rule? Look over this PR checklist

- [x] The issue has a reproduction and expected behavior
- [x] The rule has true-positive and true-negative cases in a matching test file
- [x] The message describes the condition, its risk, and a safer configuration

## Summary

- Detect Docker Compose services whose direct `user` setting selects `root` or UID `0`
- Cover quoted values and optional group identifiers
- Avoid findings for non-root users, interpolated users, root-only groups, nested extension settings, and service templates outside `services`

## Validation

- New rule tests pass with Semgrep 1.176.0
- Full Docker Compose security-rule suite passes with Semgrep 1.169.0
- Rule configuration and metadata validation pass
- Repository pre-commit hooks pass in Linux
- Semgrep default ruleset reports zero findings in the rule definition
- Detect-secrets and Gitleaks report zero findings
