### PR TITLE
fix: preserve path taint through replace calls

### DIFF
--- a/javascript/express/security/audit/express-path-join-resolve-traversal.js
+++ b/javascript/express/security/audit/express-path-join-resolve-traversal.js
@@ -51,6 +51,12 @@ app.post('/test5', function (req,res) {
     }
 })
 
+app.get('/test-replace', function (req,res) {
+    const sanitized = req.query.path.replace(/\.\.\//g, '');
+    // ruleid:express-path-join-resolve-traversal
+    return path.join(opts.path, sanitized);
+})
+
 app.post('/ok-test1', function okTest1(req,res) {
     let data = ['one', 'two', 'three'];
     for (let x of data) {
@@ -71,10 +77,10 @@ app.post('/ok-test2', function okTest2() {
     someFunc()
 })
 
-app.post('/ok-test3', function (req,res) {
+app.post('/test-replace-prefix', function testReplacePrefix(req,res) {
     let somePath = req.body.path;
     somePath = somePath.replace(/^(\.\.(\/|\\|$))+/, '');
-    // ok:express-path-join-resolve-traversal
+    // ruleid:express-path-join-resolve-traversal
     return path.join(opts.path, somePath);
 })
 

--- a/javascript/express/security/audit/express-path-join-resolve-traversal.yaml
+++ b/javascript/express/security/audit/express-path-join-resolve-traversal.yaml
@@ -82,7 +82,6 @@ rules:
       - pattern: path.join(...,$SINK,...)
       - pattern: path.resolve(...,$SINK,...)
   pattern-sanitizers:
-  - pattern: $Y.replace(...)
   - pattern: $Y.indexOf(...)
   - pattern: |
       function ... (...) {

--- a/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.js
+++ b/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.js
@@ -36,6 +36,12 @@ function test4(req,res) {
     })
 }
 
+function testReplace(userInput) {
+    const sanitized = userInput.replace(/\.\.\//g, '');
+    // ruleid:path-join-resolve-traversal
+    return path.join('/tmp/semgrep-root', sanitized);
+}
+
 function okTest1(req,res) {
     let data = ['one', 'two', 'three'];
     for (let x of data) {
@@ -56,10 +62,10 @@ function okTest2() {
     someFunc()
 }
 
-function okTest3(req,res) {
+function testReplacePrefix(req,res) {
     let somePath = req.body.path;
     somePath = somePath.replace(/^(\.\.(\/|\\|$))+/, '');
-    // ok:path-join-resolve-traversal
+    // ruleid:path-join-resolve-traversal
     return path.join(opts.path, somePath);
 }
 

--- a/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.ts
+++ b/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.ts
@@ -46,6 +46,12 @@ function test5(req,res) {
     }
 }
 
+function testReplace(userInput: string) {
+    const sanitized = userInput.replace(/\.\.\//g, '');
+    // ruleid:path-join-resolve-traversal
+    return join('/tmp/semgrep-root', sanitized);
+}
+
 function okTest1(req,res) {
     let data = ['one', 'two', 'three'];
     for (let x of data) {
@@ -66,10 +72,10 @@ function okTest2() {
     someFunc()
 }
 
-function okTest3(req,res) {
+function testReplacePrefix(req,res) {
     let somePath = req.body.path;
     somePath = somePath.replace(/^(\.\.(\/|\\|$))+/, '');
-    // ok:path-join-resolve-traversal
+    // ruleid:path-join-resolve-traversal
     return join(opts.path, somePath);
 }
 

--- a/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.yaml
+++ b/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.yaml
@@ -60,7 +60,6 @@ rules:
       - pattern-inside: path.join(...,$SINK,...)
       - pattern-inside: path.resolve(...,$SINK,...)
   pattern-sanitizers:
-  - pattern: $Y.replace(...)
   - pattern: $Y.indexOf(...)
   - pattern: |
       function ... (...) {


### PR DESCRIPTION
## Link to an issue, if relevant

Fixes #4044

## Summary

- Remove blanket `replace(...)` sanitization from both path traversal rules
- Treat prefix-only traversal stripping as unsafe because a single replacement pass can expose another traversal sequence
- Add regression coverage for Express, JavaScript, and TypeScript while preserving explicit containment and named-sanitizer cases

## Validation

- New regression cases fail before the rule change and pass afterward
- Targeted tests pass with Semgrep 1.176.0
- Targeted compatibility tests pass with Semgrep 1.170.0, the version from the issue report
- Rule configuration and metadata validation pass
- Repository pre-commit hooks pass in Linux
- Semgrep default ruleset reports zero findings in the rule definitions
- Detect-secrets and Gitleaks report zero findings
