### PR TITLE
Add rule: github-actions-checkout-persist-credentials (checkout leaves GitHub token in git config)

### DIFF
--- a/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
+++ b/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
@@ -43,6 +43,16 @@ jobs:
         with:
           fetch-depth: 1
 
+  # TP-5: case-insensitive action reference (GitHub resolves Actions/Checkout
+  # the same as actions/checkout) — regression for case-sensitivity
+  mixed_case:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: github-actions-checkout-persist-credentials
+      - uses: Actions/Checkout@v4
+        with:
+          fetch-depth: 0
+
   # OK-1: persist-credentials: false — the safe configuration
   safe:
     runs-on: ubuntu-latest

--- a/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
+++ b/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # ruleid: github-actions-checkout-persist-credentials
-      - uses: Actions/Checkout@v4
+  - uses: Actions/Checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
+++ b/yaml/github-actions/security/github-actions-checkout-persist-credentials.test.yaml
@@ -1,0 +1,71 @@
+# Test cases for github-actions-checkout-persist-credentials.
+# Default for actions/checkout `persist-credentials` is TRUE — only an explicit
+# `persist-credentials: false` is safe.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # TP-1: checkout with no `with:` block at all — token persisted by default
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@v4
+      - run: make build
+
+  # TP-2: `with:` present but persist-credentials not set — still default true
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: npm ci && npm test
+
+  # TP-3: persist-credentials explicitly true — worst case
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: some-org/third-party-linter@v1
+
+  # TP-4: pinned checkout by SHA, still missing the setting
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 1
+
+  # OK-1: persist-credentials: false — the safe configuration
+  safe:
+    runs-on: ubuntu-latest
+    steps:
+      # ok: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: make build
+
+  # OK-2: quoted 'false' (GitHub treats it as false)
+  safe_quoted:
+    runs-on: ubuntu-latest
+    steps:
+      # ok: github-actions-checkout-persist-credentials
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
+
+  # OK-3: unrelated action without `with:` must not match
+  other:
+    runs-on: ubuntu-latest
+    steps:
+      # ok: github-actions-checkout-persist-credentials
+      - uses: actions/setup-node@v4
+      - run: node --version

--- a/yaml/github-actions/security/github-actions-checkout-persist-credentials.yaml
+++ b/yaml/github-actions/security/github-actions-checkout-persist-credentials.yaml
@@ -60,5 +60,5 @@ rules:
       ...
   - metavariable-regex:
       metavariable: $ACTION
-      regex: actions/checkout(@.*)?
+      regex: (?i)actions/checkout(@.*)?
   severity: WARNING

--- a/yaml/github-actions/security/github-actions-checkout-persist-credentials.yaml
+++ b/yaml/github-actions/security/github-actions-checkout-persist-credentials.yaml
@@ -1,0 +1,64 @@
+rules:
+- id: github-actions-checkout-persist-credentials
+  languages:
+  - yaml
+  message: >-
+    This workflow uses `actions/checkout` without setting `persist-credentials: false`.
+    By default, `actions/checkout` writes the repository credential (the job's
+    `GITHUB_TOKEN` or a supplied token) into the local git config
+    (`.git/config`), where it remains readable by every subsequent step in the
+    job — including third-party actions, build scripts, and dependency
+    installation hooks. If any later step is compromised (for example through a
+    malicious or hijacked action, or a supply-chain attack on a build
+    dependency), it can exfiltrate the persisted token and use it to push code,
+    approve pull requests, or access other repositories the token can reach.
+    Unless a later step in the same job genuinely needs the persisted git
+    credential, set `persist-credentials: false` on the checkout step and pass
+    an explicitly scoped token only to the steps that need one.
+  metadata:
+    category: security
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    cwe:
+    - 'CWE-522: Insufficiently Protected Credentials'
+    references:
+    - https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
+    - https://github.com/actions/checkout#usage
+    - https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+    technology:
+    - github-actions
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: HIGH
+  patterns:
+  - pattern-inside: |
+      jobs:
+        ...
+        $JOBNAME:
+          ...
+          steps:
+            ...
+  - pattern: |
+      ...
+      uses: "$ACTION"
+      ...
+  - pattern-not: |
+      ...
+      uses: "$ACTION"
+      with:
+        ...
+        persist-credentials: false
+      ...
+  - pattern-not: |
+      ...
+      uses: "$ACTION"
+      with:
+        ...
+        persist-credentials: 'false'
+      ...
+  - metavariable-regex:
+      metavariable: $ACTION
+      regex: actions/checkout(@.*)?
+  severity: WARNING


### PR DESCRIPTION
## Add rule: `github-actions-checkout-persist-credentials`

**What it detects:** `actions/checkout` steps that do not set
`persist-credentials: false`. The checkout action's default (`true`) writes the
job's GitHub token into the runner's `.git/config`, where every subsequent step
in the job — including third-party actions and dependency install hooks — can
read it. A compromised later step can exfiltrate the token and push code or
access other APIs within the token's scope. This class of leak was documented
in Palo Alto Unit 42's "ArtiPACKED" research and is called out in GitHub's own
security-hardening guidance; `zizmor` flags it as `artipacked`, but I couldn't
find coverage in this registry (`persist-credentials` has no hits repo-wide).

**Why WARNING / audit:** it's a hardening gap rather than a directly
exploitable vuln — workflows that legitimately push after checkout will flag
and should consciously accept or scope the credential instead.

**Coverage:** matches bare `uses: actions/checkout@…`, `with:` blocks missing
the key, and explicit `persist-credentials: true`; excludes `false` and quoted
`'false'` (GitHub coerces the string). Test file includes 4 true positives and
3 negatives; `semgrep --test` passes.

**Limitation:** does not trace composite actions or reusable workflows that
wrap checkout — single-file static analysis only.

Happy to adjust message wording, metadata, or severity to registry conventions.
