### PR TITLE
fix: stop treating realpath/abspath as complete path sanitizers

### DIFF
--- a/ai/ai-best-practices/hooks-path-traversal/hooks-path-traversal-python.py
+++ b/ai/ai-best-practices/hooks-path-traversal/hooks-path-traversal-python.py
@@ -20,15 +20,20 @@ payload = json.loads(sys.stdin.read())
 # ruleid: hooks-path-traversal-python
 p = pathlib.Path(payload["file"])
 
-# ok: hooks-path-traversal-python
+# ruleid: hooks-path-traversal-python
 data = json.loads(sys.stdin.read())
-safe_path = os.path.realpath(data["file_path"])
-f = open(safe_path, "r")
+resolved_path = os.path.realpath(data["file_path"])
+f = open(resolved_path, "r")
 
-# ok: hooks-path-traversal-python
+# ruleid: hooks-path-traversal-python
 data = json.loads(sys.stdin.read())
 abs_path = os.path.abspath(data["file_path"])
 os.remove(abs_path)
+
+# ok: hooks-path-traversal-python
+data = json.loads(sys.stdin.read())
+safe_path = validate_path(data["file_path"])
+f = open(safe_path, "r")
 
 # ok: hooks-path-traversal-python
 hardcoded = open("/tmp/known_file.txt", "r")

--- a/ai/ai-best-practices/hooks-path-traversal/hooks-path-traversal-python.yaml
+++ b/ai/ai-best-practices/hooks-path-traversal/hooks-path-traversal-python.yaml
@@ -7,8 +7,10 @@ rules:
       Hook input flows into a file path without validation. Claude Code and Cursor hooks
       receive JSON input that may contain user-controlled paths. An attacker
       could craft input with path traversal sequences (e.g., '../../etc/passwd')
-      to read, modify, or delete arbitrary files. Use os.path.realpath() or
-      os.path.abspath() to resolve and validate paths before file operations.
+      to read, modify, or delete arbitrary files. os.path.realpath() and
+      os.path.abspath() only normalize a path, they don't confirm it stays inside
+      an allowed directory. Resolve the path and then check it with a validation
+      function like validate_path() before performing file operations.
     metadata:
       cwe: "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
       category: security
@@ -43,5 +45,4 @@ rules:
           - pattern: pathlib.Path($SINK)
           - focus-metavariable: $SINK
     pattern-sanitizers:
-      - pattern: os.path.realpath(...)
-      - pattern: os.path.abspath(...)
+      - pattern: validate_path(...)

--- a/ai/ai-best-practices/hooks-sensitive-file-access/hooks-sensitive-file-access-python.py
+++ b/ai/ai-best-practices/hooks-sensitive-file-access/hooks-sensitive-file-access-python.py
@@ -24,10 +24,10 @@ data = json.loads(sys.stdin.read())
 path = validate_path(data["file_path"])
 f = open(path, "r")
 
-# ok: hooks-sensitive-file-access-python
+# ruleid: hooks-sensitive-file-access-python
 data = json.loads(sys.stdin.read())
-safe_path = os.path.realpath(data["file_path"])
-f = open(safe_path, "r")
+resolved_path = os.path.realpath(data["file_path"])
+f = open(resolved_path, "r")
 
 # ok: hooks-sensitive-file-access-python
 hardcoded = open("/tmp/known_file.txt", "r")

--- a/ai/ai-best-practices/hooks-sensitive-file-access/hooks-sensitive-file-access-python.yaml
+++ b/ai/ai-best-practices/hooks-sensitive-file-access/hooks-sensitive-file-access-python.yaml
@@ -40,4 +40,3 @@ rules:
       - pattern: validate_path(...)
       - pattern: check_sensitive(...)
       - pattern: is_sensitive(...)
-      - pattern: os.path.realpath(...)


### PR DESCRIPTION
## Link to an issue, if relevant

Fixes #4045
Fixes #4046

## Summary

Both `hooks-sensitive-file-access-python` and `hooks-path-traversal-python` list `os.path.realpath(...)` (and `abspath()` for the traversal rule) as a full taint sanitizer. Neither call does any actual checking, it just resolves symlinks and relative segments. So code like this gets zero findings from either rule:

```python
data = json.loads(sys.stdin.read())
path = os.path.realpath(data["file_path"])
with open(path, "r") as f:
    ...
```

That's a real bypass. Wrap a literal `~/.ssh/id_rsa`, `.env`, or `/etc/hosts` path in `realpath()` before the `open()` call, and both rules go silent, even though this is exactly the flow they're supposed to catch.

I dropped `realpath()`/`abspath()` from `pattern-sanitizers` in both files. The sensitive-file-access rule already has a named-validator convention (`validate_path()`, `check_sensitive()`, `is_sensitive()`), so that stays as-is and still works. For path-traversal I reworded the message too, since it was telling people realpath/abspath alone was enough. That's the bug.

## Validation

Ran both rules against the bundled test fixtures and against the exact repros from the two issues:

- `hooks-sensitive-file-access-python.py`: 5/5 `ruleid` cases now flagged, remaining `ok` cases (validate_path, hardcoded path) stay clean
- `hooks-path-traversal-python.py`: 6/6 `ruleid` cases now flagged (added a `validate_path()` ok-case to keep a legitimate sanitizer path), remaining `ok` cases stay clean
- Standalone repro from #4046 (`.env` read via `os.path.realpath`) now produces 1 finding, was 0 before
- Standalone repro from #4045 (`/etc/hosts` read via `os.path.realpath`) now produces 1 finding, was 0 before
- `semgrep --validate` passes on both rule files

I checked #4049 first since it's a related sanitizer-bypass fix, but it only touches the JS path-join-resolve-traversal rules, not these Python files, so no overlap.
