### PR TITLE
fix(ci): send admin token to /update-registry

### DIFF
--- a/.github/workflows/update-semgrep-dev.yml
+++ b/.github/workflows/update-semgrep-dev.yml
@@ -10,6 +10,15 @@ jobs:
     if: github.repository == 'semgrep/semgrep-rules'
     name: Update semgrep.dev
     runs-on: ubuntu-latest
+    # POST /api/admin/update-registry is admin-gated (SECENG-12). Send an admin
+    # machine token from a secret; never hardcode it.
+    # DEPENDS ON semgrep-app accepting an admin machine token on this endpoint
+    # (today it requires a JWT, so a static token returns 404). Tracked by SECENG-12.
+    env:
+      REGISTRY_ADMIN_TOKEN_PROD: ${{ secrets.REGISTRY_ADMIN_TOKEN_PROD }}
     steps:
     - name: update semgrep.dev
-      run: curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry?rule_type=sast
+      run: |
+        curl --fail --silent --show-error -X POST -L \
+          -H "Authorization: Bearer ${REGISTRY_ADMIN_TOKEN_PROD}" \
+          "https://semgrep.dev/api/admin/update-registry?rule_type=sast"

--- a/.github/workflows/update-semgrep-staging-dev.yml
+++ b/.github/workflows/update-semgrep-staging-dev.yml
@@ -3,19 +3,35 @@ name: Deploy to dev.semgrep.dev and staging.semgrep.dev
 on:
   push:
     branches:
-    - develop 
+    - develop
 
 jobs:
   do-update:
     if: github.repository == 'semgrep/semgrep-rules'
     name: Update semgrep.dev
     runs-on: ubuntu-latest
+    # Per-host Semgrep admin tokens (SECENG-12). Each host is a separate deployment
+    # with its own admin users, so tokens are per host. Never hardcode; use secrets.
+    # DEPENDS ON semgrep-app accepting an admin machine token on this endpoint.
+    env:
+      REGISTRY_ADMIN_TOKEN_DEV2: ${{ secrets.REGISTRY_ADMIN_TOKEN_DEV2 }}
+      REGISTRY_ADMIN_TOKEN_DEV3: ${{ secrets.REGISTRY_ADMIN_TOKEN_DEV3 }}
+      REGISTRY_ADMIN_TOKEN_STAGING: ${{ secrets.REGISTRY_ADMIN_TOKEN_STAGING }}
     steps:
     - name: update dev2.semgrep.dev
-      run: curl --fail -X POST -L https://dev2.semgrep.dev/api/admin/update-registry?rule_type=sast
+      run: |
+        curl --fail --silent --show-error -X POST -L \
+          -H "Authorization: Bearer ${REGISTRY_ADMIN_TOKEN_DEV2}" \
+          "https://dev2.semgrep.dev/api/admin/update-registry?rule_type=sast"
       continue-on-error: true
     - name: update dev3.semgrep.dev
-      run: curl --fail -X POST -L https://dev3.semgrep.dev/api/admin/update-registry?rule_type=sast
+      run: |
+        curl --fail --silent --show-error -X POST -L \
+          -H "Authorization: Bearer ${REGISTRY_ADMIN_TOKEN_DEV3}" \
+          "https://dev3.semgrep.dev/api/admin/update-registry?rule_type=sast"
       continue-on-error: true
     - name: update staging.semgrep.dev
-      run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry?rule_type=sast
+      run: |
+        curl --fail --silent --show-error -X POST -L \
+          -H "Authorization: Bearer ${REGISTRY_ADMIN_TOKEN_STAGING}" \
+          "https://staging.semgrep.dev/api/admin/update-registry?rule_type=sast"


### PR DESCRIPTION
## Context

Forward-fix (SECENG-12) so this repo's deploy workflows authenticate to
`POST /api/admin/update-registry`, which became admin-gated in semgrep-app #31558.
Both workflows call it **unauthenticated**, so calls now 401. Lewis flagged this repo as
a caller (lower priority than sca-rules / -proprietary / -secrets, but included for
completeness).

## What this changes

- `update-semgrep-dev.yml` (release → semgrep.dev): admin token header.
- `update-semgrep-staging-dev.yml` (develop → dev2, dev3, staging): per-host token header.

Per-host tokens (`REGISTRY_ADMIN_TOKEN_<TENANT>`). No secrets hardcoded; masked env vars,
no `set -x`.

## ⚠️ Prerequisites — inert until both are done

1. **semgrep-app must accept an admin machine token on this endpoint** (today requires a
   JWT → static token 404s). Auth change → Security review. SECENG-12.
2. **Per-host admin tokens provisioned as secrets**, each for an `is_admin` user on that host.

`update-semgrep-dev.yml` runs on `release`; promote there after this merges to default.

## Security

Adds auth to a currently unauthenticated caller. Sensitive piece is the semgrep-app
enabling change — route through int-security. Sibling PRs: semgrep/sca-rules#9004,
semgrep/semgrep-rules-secrets#638, semgrep/semgrep-rules-proprietary#939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)