### PR TITLE
atul/code-9044-rule-request-false-negative-in-a-php-rule

### DIFF
--- a/php/lang/security/exec-use.yaml
+++ b/php/lang/security/exec-use.yaml
@@ -5,7 +5,7 @@ rules:
   - pattern-not: $FUNC('...', ...);
   - metavariable-regex:
       metavariable: $FUNC
-      regex: exec|passthru|proc_open|popen|shell_exec|system|pcntl_exec
+      regex: (?i)exec|passthru|proc_open|popen|shell_exec|system|pcntl_exec
   message: >-
     Executing non-constant commands. This can lead to command injection.
   metadata:


### PR DESCRIPTION
Updating the regex to be case-insensitive by prefixing it with (?i). This ensures calls with differently cased function or class names are detected.