### PR TITLE
feat(ai): add langchain-allow-dangerous-flags rule

### DIFF
--- a/ai/ai-best-practices/langchain-allow-dangerous-flags/langchain-allow-dangerous-flags.py
+++ b/ai/ai-best-practices/langchain-allow-dangerous-flags/langchain-allow-dangerous-flags.py
@@ -1,0 +1,24 @@
+from langchain_experimental.agents import create_pandas_dataframe_agent
+from langchain_community.vectorstores import FAISS
+from langchain_community.utilities import RequestsWrapper
+
+# ruleid: langchain-allow-dangerous-flags-python
+agent = create_pandas_dataframe_agent(llm, df, allow_dangerous_code=True)
+
+# ruleid: langchain-allow-dangerous-flags-python
+store = FAISS.load_local(path, embeddings, allow_dangerous_deserialization=True)
+
+# ruleid: langchain-allow-dangerous-flags-python
+requests_wrapper = RequestsWrapper(allow_dangerous_requests=True)
+
+# ruleid: langchain-allow-dangerous-flags-python
+config = {"model": "gpt-4", "allow_dangerous_code": True}
+
+# ok: langchain-allow-dangerous-flags-python
+safe_agent = create_pandas_dataframe_agent(llm, df, allow_dangerous_code=False)
+
+# ok: langchain-allow-dangerous-flags-python
+safe_store = FAISS.load_local(path, embeddings)
+
+# ok: langchain-allow-dangerous-flags-python
+safe_config = {"model": "gpt-4", "allow_dangerous_code": False}

--- a/ai/ai-best-practices/langchain-allow-dangerous-flags/langchain-allow-dangerous-flags.yaml
+++ b/ai/ai-best-practices/langchain-allow-dangerous-flags/langchain-allow-dangerous-flags.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: langchain-allow-dangerous-flags-python
+    languages: [python]
+    severity: ERROR
+    message: >-
+      A LangChain "dangerous" capability flag is explicitly enabled.
+      `allow_dangerous_code=True` lets an LLM-generated payload execute as
+      Python; `allow_dangerous_deserialization=True` unpickles data, which is
+      arbitrary code execution unless the source is fully trusted; and
+      `allow_dangerous_requests=True` permits unrestricted outbound HTTP,
+      which reaches internal services and cloud metadata endpoints (SSRF).
+      LangChain gates each of these behind an explicit opt-in precisely
+      because enabling it removes the safety boundary: if any part of the
+      chain's input is attacker-influenced, prompt injection escalates to
+      code execution or SSRF. Only enable these when every input and model
+      source is fully trusted.
+    metadata:
+      cwe: "CWE-94: Improper Control of Generation of Code ('Code Injection')"
+      category: security
+      confidence: HIGH
+      subcategory: [audit]
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [langchain]
+      references:
+        - https://python.langchain.com/docs/security/
+    pattern-either:
+      - pattern: $OBJ(..., allow_dangerous_code=True, ...)
+      - pattern: $OBJ(..., allow_dangerous_deserialization=True, ...)
+      - pattern: $OBJ(..., allow_dangerous_requests=True, ...)
+      - pattern: '{..., "allow_dangerous_code": True, ...}'
+      - pattern: '{..., "allow_dangerous_deserialization": True, ...}'
+      - pattern: '{..., "allow_dangerous_requests": True, ...}'


### PR DESCRIPTION
## Summary

Adds `langchain-allow-dangerous-flags-python`, detecting explicit enabling of LangChain's three "dangerous" capability flags:

- `allow_dangerous_code=True` — lets LLM-generated payloads execute as Python
- `allow_dangerous_deserialization=True` — unpickles data (arbitrary code execution unless the source is fully trusted)
- `allow_dangerous_requests=True` — permits unrestricted outbound HTTP, reaching internal services and cloud metadata endpoints (SSRF)

LangChain gates each of these behind an explicit opt-in precisely because enabling it removes a safety boundary. When any part of a chain's input is attacker-influenced, prompt injection escalates to code execution or SSRF.

## Why this isn't already covered

The existing `ai/ai-best-practices/langchain-dangerous-exec` rule covers the execution *utilities* (`PythonREPL`, `BashProcess`, `PythonAstREPLTool`), but nothing in the repo currently matches these opt-in flags — I searched for `allow_dangerous_code`, `allow_dangerous_deserialization`, and `allow_dangerous_requests` across the repository and found no existing coverage.

The rule follows the conventions of its `langchain-dangerous-exec` sibling (directory layout, metadata shape, `technology: [langchain]`).

## Test plan

- [x] `semgrep --test` passes on the rule + its annotated test file (`1/1: ✓ All tests passed`)
- [x] Test file covers all three flags, the config-dict form, and negative cases (flag set to `False`, flag absent)
- [x] Validated against [Langflow](https://github.com/langflow-ai/langflow), a real LangChain-based project: **zero findings** across its backend source (no false positives)
- [x] The config-dict pattern was confirmed against a genuine real-world usage found in Langflow's own test suite (`{"allow_dangerous_code": True, ...}`), so the pattern is verified against real code rather than only synthetic examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm2SdsjpnfHmhPzbA8mYkM