### PR TITLE
feat(php): add wp-xss-audit rule for WordPress plugins

### DIFF
--- a/php/wordpress-plugins/security/audit/wp-xss-audit.php
+++ b/php/wordpress-plugins/security/audit/wp-xss-audit.php
@@ -1,0 +1,54 @@
+<?php
+
+$name = $_GET['name'];
+// ruleid: wp-xss-audit
+echo $name;
+
+// ruleid: wp-xss-audit
+echo $_POST['comment'];
+
+// ruleid: wp-xss-audit
+print $_REQUEST['search'];
+
+$term = $_GET['term'];
+// ruleid: wp-xss-audit
+printf('<span>%s</span>', $term);
+
+$paged = get_query_var('paged');
+// ruleid: wp-xss-audit
+echo $paged;
+
+$page = $wp_query->get('paged');
+// ruleid: wp-xss-audit
+echo $page;
+
+$title = get_option('site_tagline');
+// ruleid: wp-xss-audit
+echo $title;
+
+$bio = get_user_meta(get_current_user_id(), 'bio', true);
+// ruleid: wp-xss-audit
+echo $bio;
+
+// ok: wp-xss-audit
+echo esc_html($_GET['name']);
+
+// ok: wp-xss-audit
+echo esc_attr(get_query_var('paged'));
+
+// ok: wp-xss-audit
+echo intval($wp_query->get('paged'));
+
+// ok: wp-xss-audit
+echo wp_kses_post($_POST['comment']);
+
+// ok: wp-xss-audit
+echo sanitize_text_field($_REQUEST['search']);
+
+// ok: wp-xss-audit
+echo esc_url($_GET['redirect']);
+
+// ok: wp-xss-audit
+echo '<span>Static markup</span>';
+
+?>

--- a/php/wordpress-plugins/security/audit/wp-xss-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-xss-audit.yaml
@@ -1,0 +1,72 @@
+rules:
+- id: wp-xss-audit
+  languages:
+  - php
+  severity: WARNING
+  message: >-
+    Detected user input flowing into an output sink without escaping, which could
+    lead to cross-site scripting (XSS). Escape the value for its output context
+    before printing it - esc_html() for element text, esc_attr() for attribute
+    values, esc_url() for URLs, esc_js() for inline script data, or
+    wp_kses()/wp_kses_post() when limited HTML must be preserved. Values that
+    should be numeric can be cast with intval()/absint() instead.
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern-either:
+        - pattern: $_GET[...]
+        - pattern: $_POST[...]
+        - pattern: $_REQUEST[...]
+        - pattern: get_option(...)
+        - pattern: get_user_meta(...)
+        - pattern: get_query_var(...)
+        - pattern: $wp_query->get(...)
+  pattern-sanitizers:
+    - patterns:
+      - pattern-either:
+        - pattern: esc_html(...)
+        - pattern: esc_html__(...)
+        - pattern: esc_html_e(...)
+        - pattern: esc_attr(...)
+        - pattern: esc_attr__(...)
+        - pattern: esc_attr_e(...)
+        - pattern: esc_url(...)
+        - pattern: esc_url_raw(...)
+        - pattern: esc_js(...)
+        - pattern: esc_textarea(...)
+        - pattern: wp_kses(...)
+        - pattern: wp_kses_post(...)
+        - pattern: sanitize_text_field(...)
+        - pattern: htmlspecialchars(...)
+        - pattern: htmlentities(...)
+        - pattern: intval(...)
+        - pattern: absint(...)
+        - pattern: floatval(...)
+  pattern-sinks:
+    - patterns:
+      - focus-metavariable: $SINK
+      - pattern-either:
+        - pattern: echo $SINK;
+        - pattern: print $SINK;
+        - pattern: printf($FMT, ..., $SINK, ...)
+  paths:
+    include:
+    - '**/wp-content/plugins/**/*.php'
+  metadata:
+    cwe: 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp: A03:2021 - Injection
+    category: security
+    confidence: MEDIUM
+    likelihood: MEDIUM
+    impact: MEDIUM
+    subcategory:
+    - audit
+    technology:
+    - Wordpress Plugins
+    references:
+    - https://developer.wordpress.org/apis/security/escaping/
+    - https://developer.wordpress.org/reference/functions/esc_html/
+    - https://developer.wordpress.org/reference/functions/wp_kses/
+    vulnerability_class:
+    - Cross-Site Scripting (XSS)


### PR DESCRIPTION
## Summary

Adds `wp-xss-audit` to the WordPress plugin audit rule set.

That rule set currently covers SSRF, SQL injection, CSRF, code execution, command execution, file inclusion, file download, file manipulation, PHP object injection, open redirect, authorisation checks, and AJAX hooks — but has no rule for cross-site scripting, which is the most commonly reported WordPress plugin vulnerability class.

## Approach

The rule deliberately reuses the taint sources already established by the neighbouring `wp-ssrf-audit` rule (`$_GET`, `$_POST`, `$_REQUEST`, `get_option()`, `get_user_meta()`, `get_query_var()`) and applies them to output sinks (`echo`, `print`, `printf`), so the source model stays consistent across the rule set.

It additionally models **`$wp_query->get()`**, which returns request-influenced data at the same trust level as `$_GET` (e.g. `?paged=`) but is not currently modelled as a taint source anywhere in this repository. It is matched against the literal `$wp_query` global rather than a bare metavariable receiver, since `->get()` is an extremely common accessor name across unrelated frameworks and a metavariable receiver would be far broader than intended.

Escaping and casting functions are declared as sanitizers (`esc_html`, `esc_attr`, `esc_url`, `esc_js`, `esc_textarea`, `wp_kses`, `wp_kses_post`, `sanitize_text_field`, `htmlspecialchars`, `intval`, `absint`, ...), so correctly written plugin code does not produce findings.

Follows the conventions of the existing rules in this directory: `mode: taint`, the same `paths: include` plugin scoping, and the same metadata shape.

## Test plan

- [x] `semgrep --test` passes on the rule and its annotated test file (`1/1: ✓ All tests passed`)
- [x] Test file covers each taint source, both sink shapes, and negative cases for every sanitizer category
- [x] Validated against [Yoast SEO](https://github.com/Yoast/wordpress-seo) (3,180 PHP files from a production plugin): **zero findings**
- [x] That same scan run also included positive controls, which were correctly flagged — both the bare `echo $var;` shape and the more realistic string-concatenation shape (`echo '<body class="paged-' . $page . '">';`) — with their `esc_attr()`-escaped equivalents correctly suppressed. The zero-finding result above is therefore a genuine true-negative on real code, not a rule that silently fails to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm2SdsjpnfHmhPzbA8mYkM