### PR TITLE
Add rule: Supabase service role key exposed via NEXT_PUBLIC_ env var

### DIFF
--- a/javascript/supabase/security/supabase-service-role-key-public-env.ts
+++ b/javascript/supabase/security/supabase-service-role-key-public-env.ts
@@ -1,0 +1,27 @@
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+// ruleid: supabase-service-role-key-public-env
+const adminKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY;
+
+export const admin = createClient(
+  url,
+  // ruleid: supabase-service-role-key-public-env
+  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
+);
+
+// ruleid: supabase-service-role-key-public-env
+const k2 = process.env["NEXT_PUBLIC_SERVICE_KEY"];
+
+// ruleid: supabase-service-role-key-public-env
+const { NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY } = process.env;
+
+// ok: supabase-service-role-key-public-env
+const serverKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// ok: supabase-service-role-key-public-env
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+// ok: supabase-service-role-key-public-env
+export const server = createClient(url, process.env.SUPABASE_SERVICE_ROLE_KEY!);

--- a/javascript/supabase/security/supabase-service-role-key-public-env.yaml
+++ b/javascript/supabase/security/supabase-service-role-key-public-env.yaml
@@ -1,0 +1,51 @@
+rules:
+- id: supabase-service-role-key-public-env
+  message: >-
+    The Supabase service role key is read from an environment variable with the
+    'NEXT_PUBLIC_' prefix. Next.js inlines every 'NEXT_PUBLIC_' variable into the
+    JavaScript bundle sent to the browser, so anyone can extract this key. The
+    service role key bypasses Row Level Security (RLS) and grants full read/write
+    access to the database. Rename the variable without the 'NEXT_PUBLIC_' prefix,
+    use it only in server-side code (e.g. with `import "server-only"`), and rotate
+    the leaked key in the Supabase dashboard.
+  metadata:
+    cwe:
+    - 'CWE-200: Exposure of Sensitive Information to an Unauthorized Actor'
+    - 'CWE-522: Insufficiently Protected Credentials'
+    owasp:
+    - A01:2021 - Broken Access Control
+    - A05:2021 - Security Misconfiguration
+    - A01:2025 - Broken Access Control
+    - A02:2025 - Security Misconfiguration
+    category: security
+    technology:
+    - supabase
+    - nextjs
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: HIGH
+    references:
+    - https://nextjs.org/docs/app/guides/environment-variables#bundling-environment-variables-for-the-browser
+    - https://supabase.com/docs/guides/api/api-keys
+  languages:
+  - javascript
+  - typescript
+  severity: ERROR
+  pattern-either:
+  - patterns:
+    - pattern: process.env.$VAR
+    - metavariable-regex:
+        metavariable: $VAR
+        regex: (?i)^NEXT_PUBLIC_.*SERVICE_(ROLE|KEY)
+  - patterns:
+    - pattern: process.env[$VAR]
+    - metavariable-regex:
+        metavariable: $VAR
+        regex: (?i)^["'`]NEXT_PUBLIC_.*SERVICE_(ROLE|KEY)
+  - patterns:
+    - pattern: const {$VAR} = process.env
+    - metavariable-regex:
+        metavariable: $VAR
+        regex: (?i)^NEXT_PUBLIC_.*SERVICE_(ROLE|KEY)


### PR DESCRIPTION
## Summary
Adds `supabase-service-role-key-public-env`, which flags reads of a Supabase
service role key from an environment variable prefixed with `NEXT_PUBLIC_`.

## Why
Next.js inlines every `NEXT_PUBLIC_*` variable into the JavaScript bundle at
build time, so it can end up shipped to the browser. The Supabase service role
key bypasses Row Level Security and grants full database access, so exposing it
is a critical misconfiguration. There is currently no rule in the registry
covering Supabase or `NEXT_PUBLIC_` exposure: running `--config auto`
(logged in, 381 rules) on a Next.js + Supabase project with this pattern
produced no findings.

## What it detects
- `process.env.NEXT_PUBLIC_*SERVICE_ROLE*` / `*SERVICE_KEY*`
- Bracket access: `process.env["NEXT_PUBLIC_..."]`
- Destructuring: `const { NEXT_PUBLIC_... } = process.env`

The public anon key (`NEXT_PUBLIC_SUPABASE_ANON_KEY`) and server-only
variables are not flagged (covered by `ok:` test cases).

## Testing
`semgrep --test` passes; `semgrep --validate` reports no errors.