### PR TITLE
python.fastapi.security.injection: add SSRF rule for httpx calls fed by route parameters

### DIFF
--- a/python/fastapi/security/injection/fastapi-httpx-ssrf.py
+++ b/python/fastapi/security/injection/fastapi-httpx-ssrf.py
@@ -1,0 +1,55 @@
+import httpx
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/proxy")
+async def proxy(url: str):
+    async with httpx.AsyncClient() as client:
+        # ruleid: fastapi-httpx-ssrf
+        return await client.get(url)
+
+
+@app.get("/status")
+async def status():
+    async with httpx.AsyncClient() as client:
+        # ok: fastapi-httpx-ssrf
+        return await client.get("https://api.interna.exemplo.com/health")
+
+
+@app.get("/proxy2")
+async def proxy2(url: str):
+    destino = url + "/dados"
+    async with httpx.AsyncClient() as client:
+        # ruleid: fastapi-httpx-ssrf
+        return await client.get(destino)
+
+
+@app.get("/proxy3")
+async def proxy3(url: str):
+    # ruleid: fastapi-httpx-ssrf
+    return httpx.get(url)
+
+
+config = {"api_interna": "https://interna.exemplo.com"}
+
+
+@app.get("/config")
+async def ver_config(url: str):
+    # ok: fastapi-httpx-ssrf
+    return config.get(url)
+
+
+@app.get("/proxy_sync")
+def proxy_sync(url: str):
+    with httpx.Client() as client:
+        # ruleid: fastapi-httpx-ssrf
+        return client.get(url)
+
+
+@app.get("/status_sync")
+def status_sync():
+    with httpx.Client() as client:
+        # ok: fastapi-httpx-ssrf
+        return client.get("https://api.interna.exemplo.com/health")

--- a/python/fastapi/security/injection/fastapi-httpx-ssrf.yaml
+++ b/python/fastapi/security/injection/fastapi-httpx-ssrf.yaml
@@ -1,0 +1,61 @@
+rules:
+  - id: fastapi-httpx-ssrf
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Data from a FastAPI route parameter is passed into an outbound httpx
+      request. This could lead to a server-side request forgery (SSRF).
+      To mitigate, validate the destination against an allowlist of hosts
+      before making the request.
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  @$APP.$METHOD(...)
+                  async def $FUNC(..., $PARAM, ...):
+                      ...
+              - pattern-inside: |
+                  @$APP.$METHOD(...)
+                  def $FUNC(..., $PARAM, ...):
+                      ...
+          - focus-metavariable: $PARAM
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-inside: |
+                      with httpx.Client() as $CLIENT:
+                          ...
+                  - pattern: $CLIENT.$METODO($URL)
+              - patterns:
+                  - pattern-inside: |
+                      async with httpx.AsyncClient() as $CLIENT:
+                          ...
+                  - pattern: $CLIENT.$METODO($URL)
+              - pattern: httpx.$METODO($URL)
+          - metavariable-regex:
+              metavariable: $METODO
+              regex: ^(get|post|put|delete|patch|head|options)$
+          - focus-metavariable: $URL
+    metadata:
+      cwe:
+        - "CWE-918: Server-Side Request Forgery (SSRF)"
+      owasp:
+        - "A10:2021 - Server-Side Request Forgery (SSRF)"
+        - "A01:2025 - Broken Access Control"
+      category: security
+      technology:
+        - python
+        - fastapi
+        - httpx
+      references:
+        - https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+        - https://cwe.mitre.org/data/definitions/918.html
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: MEDIUM
+      subcategory:
+        - vuln
+      vulnerability_class:
+        - Server-Side Request Forgery (SSRF)


### PR DESCRIPTION
Summary

Adds fastapi-httpx-ssrf, a taint-mode rule that flags FastAPI route handlers where a route parameter reaches an outbound httpx request without validation — a Server-Side Request Forgery (SSRF, CWE-918) pattern.

Motivation

python/fastapi/security/ currently has SSRF-adjacent coverage only through wildcard-cors.yaml (CORS misconfiguration), and the existing SSRF rule in this repo (python/flask/security/injection/ssrf-requests.yaml) targets Flask + requests. I checked the python/ rules directory and found no rule matching FastAPI's idiomatic async style (async def route + httpx.AsyncClient), and confirmed the gap by running the existing Flask SSRF rule against an async/httpx-based FastAPI example — it did not fire. httpx is the client most FastAPI codebases reach for specifically because it's async-native, so this is a realistic, currently-uncovered shape.

What the rule does

Taint-mode rule (mode: taint):

Source: any parameter of a FastAPI route handler (@$APP.$METHOD(...) + async def/def $FUNC(..., $PARAM, ...)) — covers both async and sync route definitions.
Sink: an httpx HTTP call reached three ways: inside with httpx.Client() as $CLIENT:, inside async with httpx.AsyncClient() as $CLIENT:, or a direct httpx.$METHOD(...) module-level call — restricted via metavariable-regex to real HTTP verbs (get, post, put, delete, patch, head, options) so it doesn't match unrelated .get(...) calls (e.g. dict lookups).
Taint propagation is left to Semgrep's default behavior, so the rule also catches the parameter being passed through an intermediate variable before reaching the sink (not just used directly).
Testing

fastapi-httpx-ssrf.py covers 7 cases, semgrep --test passes 100%:

async route, direct client.get(url) via AsyncClient → ruleid
async route, hardcoded internal URL → ok
async route, tainted value passed through an intermediate variable → ruleid
async route, direct module-level httpx.get(url) → ruleid
a dict.get(url) call unrelated to HTTP, included specifically to guard against the false positive the metavariable-regex restriction fixes → ok
sync route (def, no async), client.get(url) via httpx.Client → ruleid
sync route, hardcoded internal URL → ok
Metadata

severity: ERROR, likelihood: MEDIUM, impact: HIGH, confidence: MEDIUM, and two owasp entries (SSRF + Broken Access Control) — matched against the existing Flask and Django SSRF rules already in this repo (python/flask/security/injection/ssrf-requests.yaml, python/django/security/injection/ssrf/ssrf-injection-requests.yaml) rather than chosen independently.